### PR TITLE
feat!: WebsiteProfileでurlプロパティをallowedOriginに置換

### DIFF
--- a/apps/web-ext/e2e/data.ts
+++ b/apps/web-ext/e2e/data.ts
@@ -95,13 +95,13 @@ export function generateWebsiteProfileData(
     issuer: issuer,
     credentialSubject: {
       id: "http://localhost:8080",
-      url: "http://localhost:8080",
       type: "WebSite",
       name: "SiteProfileの取得検証",
       description: "<Webサイトの説明>",
       image: {
         id: "https://media.example.com/image.png",
       },
+      allowedOrigin: ["http://localhost:8080"],
     },
   };
 }

--- a/packages/model/src/website-profile.ts
+++ b/packages/model/src/website-profile.ts
@@ -4,7 +4,13 @@ import { OpCipContext } from "./context/op-cip-context";
 import { Image } from "./image";
 import { OpVc } from "./op-vc";
 
-const subject = {
+/**
+ * 後方互換性のため 2026-10-01 まで url プロパティを許容
+ * @deprecated
+ * @see https://github.com/originator-profile/docs.originator-profile.org/issues/451
+ */
+const deprecatedSubject = {
+  deprecated: true,
   type: "object",
   additionalProperties: true,
   properties: {
@@ -28,6 +34,32 @@ const subject = {
     url: AllowedOrigin,
   },
   required: ["id", "type", "name", "url"],
+} as const;
+
+const subject = {
+  type: "object",
+  additionalProperties: true,
+  properties: {
+    id: {
+      type: "string",
+      title: "Web サイトのオリジン (形式: https://<ホスト名>)",
+      format: "uri",
+    },
+    type: {
+      const: "WebSite",
+    },
+    name: {
+      type: "string",
+      title: "Web サイトの名称",
+    },
+    image: Image,
+    description: {
+      type: "string",
+      title: "Web サイトの説明",
+    },
+    allowedOrigin: AllowedOrigin,
+  },
+  required: ["id", "type", "name", "allowedOrigin"],
 } as const satisfies JSONSchema;
 
 export const WebsiteProfile = {
@@ -48,7 +80,9 @@ export const WebsiteProfile = {
             { const: "WebsiteProfile" },
           ],
         },
-        credentialSubject: subject,
+        credentialSubject: {
+          anyOf: [deprecatedSubject, subject],
+        },
       },
       required: ["@context", "type", "credentialSubject"],
     },

--- a/packages/opvc/README.md
+++ b/packages/opvc/README.md
@@ -398,7 +398,9 @@ FLAG DESCRIPTIONS
     "id": "https://media.example.com/image.png",
     "digestSRI": "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY="
     },
-    "url": "https://media.example.com"
+    "allowedOrigin": [
+    "https://media.example.com"
+    ]
     }
     }
 ```
@@ -450,14 +452,16 @@ FLAG DESCRIPTIONS
     "issuer": "<OP ID>",
     "credentialSubject": {
     "id": "<Web サイトのオリジン (形式: https://<ホスト名>)>",
-    "url": "<Web サイトのオリジン (形式: https://<ホスト名>)>",
     "type": "WebSite",
     "name": "<Web サイトの名称>",
     "description": "<Web サイトの説明>",
     "image": {
     "id": "<サムネイル画像URL>",
     "content": "<コンテンツ (data:// 形式URL)>"
-    }
+    },
+    "allowedOrigin": [
+    "<Web サイトのオリジン (形式: https://<ホスト名>)>"
+    ]
     }
     }
 ```

--- a/packages/opvc/src/commands/sign.ts
+++ b/packages/opvc/src/commands/sign.ts
@@ -119,7 +119,7 @@ const exampleWebsiteProfile = {
       id: "https://media.example.com/image.png",
       digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
     },
-    url: "https://media.example.com",
+    allowedOrigin: ["https://media.example.com"],
   },
 } satisfies WebsiteProfile;
 

--- a/packages/opvc/src/commands/wsp/unsigned.ts
+++ b/packages/opvc/src/commands/wsp/unsigned.ts
@@ -17,7 +17,6 @@ const exampleWebsiteProfile = {
   issuer: "<OP ID>",
   credentialSubject: {
     id: "<Web サイトのオリジン (形式: https://<ホスト名>)>",
-    url: "<Web サイトのオリジン (形式: https://<ホスト名>)>",
     type: "WebSite",
     name: "<Web サイトの名称>",
     description: "<Web サイトの説明>",
@@ -25,6 +24,7 @@ const exampleWebsiteProfile = {
       id: "<サムネイル画像URL>",
       content: "<コンテンツ (data:// 形式URL)>",
     },
+    allowedOrigin: ["<Web サイトのオリジン (形式: https://<ホスト名>)>"],
   },
 } satisfies WebsiteProfile;
 

--- a/packages/securing-mechanism/src/jwt/sign-vc.test.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.test.ts
@@ -31,7 +31,7 @@ test("signJwtVc() returns valid Website Profile", async () => {
         id: "https://media.example.com/image.png",
         digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
       },
-      url: "https://media.example.com",
+      allowedOrigin: ["https://media.example.com"],
     },
   };
   const { publicKey, privateKey } = await generateKey();

--- a/packages/verify/src/helper.ts
+++ b/packages/verify/src/helper.ts
@@ -141,11 +141,11 @@ export const wsp: WebsiteProfile = {
   type: ["VerifiableCredential", "WebsiteProfile"],
   issuer: opId.originator,
   credentialSubject: {
-    id: opId.originator,
+    id: "https://originator.example.org",
     type: "WebSite",
     name: "Example Website",
     description: "Example Website Description",
-    url: "https://originator.example.org",
+    allowedOrigin: ["https://originator.example.org"],
   },
 };
 /** CA ID */

--- a/packages/verify/src/site-profile/verify-site-profile.test.ts
+++ b/packages/verify/src/site-profile/verify-site-profile.test.ts
@@ -505,7 +505,7 @@ describe("Site Profileの検証", async () => {
     expect(resultSp).instanceOf(SiteProfileVerifyFailed);
   });
 
-  test("WSPのURLがnullの時に検証に失敗するか", async () => {
+  test("WSPのallowedOriginがnullの時に検証に失敗するか", async () => {
     const wspWithNullCredentialSubjectUrl: WebsiteProfile = {
       "@context": [
         "https://www.w3.org/ns/credentials/v2",
@@ -522,7 +522,7 @@ describe("Site Profileの検証", async () => {
         type: "WebSite",
         name: "Example Website",
         description: "Example Website Description",
-        url: "null",
+        allowedOrigin: "null",
       },
     };
 
@@ -556,7 +556,7 @@ describe("Site Profileの検証", async () => {
     expect(resultSp).instanceOf(SiteProfileVerifyFailed);
   });
 
-  test("WSPのURLとオリジンが共にnullの時に検証に失敗するか", async () => {
+  test("WSPのallowedOriginとオリジンが共にnullの時に検証に失敗するか", async () => {
     const wspWithNullCredentialSubjectUrl: WebsiteProfile = {
       "@context": [
         "https://www.w3.org/ns/credentials/v2",
@@ -573,7 +573,7 @@ describe("Site Profileの検証", async () => {
         type: "WebSite",
         name: "Example Website",
         description: "Example Website Description",
-        url: "null",
+        allowedOrigin: "null",
       },
     };
 

--- a/packages/verify/src/site-profile/verify-site-profile.ts
+++ b/packages/verify/src/site-profile/verify-site-profile.ts
@@ -1,5 +1,9 @@
 import { Keys, LocalKeys } from "@originator-profile/cryptography";
-import { SiteProfile, WebsiteProfile } from "@originator-profile/model";
+import {
+  AllowedOrigin,
+  SiteProfile,
+  WebsiteProfile,
+} from "@originator-profile/model";
 import {
   JwtVcDecoder,
   JwtVcVerifier,
@@ -83,7 +87,12 @@ export function SpVerifier(
     }
 
     if (verifyOrigin) {
-      if (!verifyAllowedOrigin(origin, decodedWsp.doc.credentialSubject.url)) {
+      const allowedOrigin =
+        "allowedOrigin" in decodedWsp.doc.credentialSubject
+          ? (decodedWsp.doc.credentialSubject.allowedOrigin as AllowedOrigin)
+          : decodedWsp.doc.credentialSubject.url; // NOTE: 後方互換性のため 2026-10-01 まで url プロパティを許容
+
+      if (!verifyAllowedOrigin(origin, allowedOrigin)) {
         return new SiteProfileVerifyFailed("Origin not allowed", {
           originators: opsVerified,
           credential,

--- a/packages/verify/src/verify-vc/website-profile.test.ts
+++ b/packages/verify/src/verify-vc/website-profile.test.ts
@@ -1,11 +1,11 @@
 import { generateKey, LocalKeys } from "@originator-profile/cryptography";
+import { WebsiteProfile } from "@originator-profile/model";
 import {
   JwtVcVerifier,
   signJwtVc,
   VcValidator,
   VerifiedJwtVc,
 } from "@originator-profile/securing-mechanism";
-import { WebsiteProfile } from "@originator-profile/model";
 import { addYears } from "date-fns";
 import { expect, test } from "vitest";
 
@@ -29,7 +29,7 @@ const websiteProfile: WebsiteProfile = {
       id: "https://media.example.com/image.png",
       digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
     },
-    url: "https://media.example.com",
+    allowedOrigin: ["https://media.example.com"],
   },
 };
 


### PR DESCRIPTION
## 変更内容

[仕様変更案: WSP id/url プロパティの目的明確化 · Issue #451 · originator-profile/docs.originator-profile.org](https://github.com/originator-profile/docs.originator-profile.org/issues/451) を踏まえた実装への反映

`url` だと検証用途であることや Origin しか許さない事が分からず混乱を生んでいるので `allowedOrigin` に名称を変更する。

https://github.com/originator-profile/docs.originator-profile.org/issues/451

## 確認手順

一連の自動テストがパスすること

## レビュアー

主要なコミッターから shuf -n2 にて選出:

- @Sa-R390
- @yutsuda
