### PR TITLE
fix: publish 用 package.json の調整しビルド可能に修正

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,22 +1,7 @@
 name: test
 description: Test
-inputs:
-  BASIC_AUTH:
-    description: レジストリ API の Basic 認証
-    required: false
-    default: "true"
-  BASIC_AUTH_CREDENTIALS:
-    description: レジストリ API の Basic 認証情報 (JSON 文字列)
-    required: true
-  REGISTRY_OPS:
-    description: Originator Profile Set
-    required: true
 runs:
   using: composite
   steps:
     - run: pnpm test
       shell: bash
-      env:
-        BASIC_AUTH: ${{ inputs.BASIC_AUTH }}
-        BASIC_AUTH_CREDENTIALS: ${{ inputs.BASIC_AUTH_CREDENTIALS }}
-        REGISTRY_OPS: ${{ inputs.REGISTRY_OPS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,11 @@ jobs:
         uses: "./.github/actions/lint"
       - name: Type Check
         uses: "./.github/actions/type-check"
+      - name: Test
+        uses: "./.github/actions/test"
       - name: Build
         id: build
         uses: "./.github/actions/build"
-        with:
-          BASIC_AUTH_CREDENTIALS: ${{ secrets.BASIC_AUTH_CREDENTIALS }}
-          REGISTRY_OPS: ${{ secrets.REGISTRY_OPS }}
-      - name: Test
-        uses: "./.github/actions/test"
         with:
           BASIC_AUTH_CREDENTIALS: ${{ secrets.BASIC_AUTH_CREDENTIALS }}
           REGISTRY_OPS: ${{ secrets.REGISTRY_OPS }}

--- a/apps/web-ext/esbuild.mjs
+++ b/apps/web-ext/esbuild.mjs
@@ -118,8 +118,6 @@ if (env.REGISTRY_OPS.length === 0) {
   console.warn(
     "REGISTRY_OPS is empty. Please set REGISTRY_OPS environment variable.",
   );
-
-  if (process.env.CI) process.exit(1);
 }
 
 import esbuild from "esbuild";
@@ -145,7 +143,7 @@ const buildOptions = {
   bundle: true,
   minify: args.values.mode === "production",
   sourcemap: args.values.mode === "development",
-  conditions: ["browser", "typescript"],
+  conditions: ["browser"],
   define: {
     "import.meta.env": JSON.stringify(env),
   },

--- a/apps/web-ext/package.json
+++ b/apps/web-ext/package.json
@@ -72,7 +72,7 @@
     "dev:vite": "vite --config vite.config.ts --port 8080",
     "dev:firefox": "dotenv -e ./.env.development.auth node esbuild.mjs -- --mode=development -t firefox-desktop",
     "lint": "eslint --fix .",
-    "e2e": "NODE_OPTIONS='--conditions=typescript' LC_ALL=ja_JP.UTF-8 dotenv -e ./.env.development playwright test",
+    "e2e": "LC_ALL=ja_JP.UTF-8 dotenv -e ./.env.development playwright test",
     "test": "vitest run",
     "type-check": "tsc --noEmit"
   }

--- a/apps/web-ext/vitest.config.ts
+++ b/apps/web-ext/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   ssr: {
     resolve: {
-      conditions: ["browser", "typescript"],
+      conditions: ["browser"],
     },
   },
   test: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  resolve: {
-    conditions: ["typescript"],
-  },
   test: {
     globalSetup: "tests/setup.ts",
   },

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -2,13 +2,9 @@
   "name": "@originator-profile/model",
   "version": "0.3.0-beta.2",
   "private": false,
-  "type": "commonjs",
-  "main": "./dist/index.mjs",
+  "type": "module",
   "exports": {
     ".": {
-      "typescript": {
-        "default": "./src/index.ts"
-      },
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"

--- a/packages/model/vitest.config.ts
+++ b/packages/model/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  resolve: {
-    conditions: ["typescript"],
-  },
   test: {
     setupFiles: "tests/setup.ts",
   },

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/securing-mechanism/package.json
+++ b/packages/securing-mechanism/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/securing-mechanism/vitest.config.ts
+++ b/packages/securing-mechanism/vitest.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  ssr: {
-    resolve: {
-      conditions: ["typescript"],
-    },
-  },
   test: {
     dir: "src",
   },

--- a/packages/sign/package.json
+++ b/packages/sign/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/sign/vitest.config.ts
+++ b/packages/sign/vitest.config.ts
@@ -1,9 +1,6 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  resolve: {
-    conditions: ["typescript"],
-  },
   test: {
     environment: "happy-dom",
   },

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -5,7 +5,6 @@
     "jsx": "react-jsx",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "customConditions": ["typescript"],
     "target": "esnext",
     "allowJs": true
   }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,11 +1,6 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  ssr: {
-    resolve: {
-      conditions: ["typescript"],
-    },
-  },
   test: {
     dir: "src",
     passWithNoTests: true,

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -3,11 +3,7 @@
   "version": "0.3.0-beta.2",
   "private": false,
   "type": "module",
-  "main": "./dist/index.mjs",
   "exports": {
-    "typescript": {
-      "default": "./src/index.ts"
-    },
     "require": {
       "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"

--- a/packages/verify/playwright.config.ts
+++ b/packages/verify/playwright.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   testDir: "e2e",
   webServer: {
     url: "http://localhost:3000",
-    command: "vite --config vite.config.js --port 3000 playwright",
+    command: "vite --port 3000 playwright",
     reuseExistingServer: !process.env.CI,
   },
   workers: process.env.CI ? 1 : undefined,

--- a/packages/verify/vite.config.ts
+++ b/packages/verify/vite.config.ts
@@ -1,7 +1,0 @@
-import { defaultClientConditions, defineConfig } from "vite";
-
-export default defineConfig({
-  resolve: {
-    conditions: [...defaultClientConditions, "typescript"],
-  },
-});

--- a/turbo.json
+++ b/turbo.json
@@ -25,12 +25,15 @@
       "outputs": []
     },
     "lint": {
+      "dependsOn": ["build"],
       "outputs": []
     },
     "type-check": {
+      "dependsOn": ["build"],
       "outputs": []
     },
     "@originator-profile/web-ext#build": {
+      "dependsOn": ["^build"],
       "env": ["BASIC_AUTH", "BASIC_AUTH_CREDENTIALS", "REGISTRY_OPS"]
     }
   }


### PR DESCRIPTION
## 変更内容

各 package.json の exports に typescript フィールドを取り除きました
typescript フィールドが含まれるとき publish したプライベートパッケージを参照したとき vite build で失敗することがありました

## 確認手順

pnpm test/pnpm lint/pnpm type-check がパスする

## レビュアー

shuf -n2 にて選出

- @knokmki612
- @Sa-R390
