### PR TITLE
fix(web-ext): getRegistryKeys()関数のJWK重複を排除

### DIFF
--- a/apps/web-ext/src/utils/get-registry-keys.ts
+++ b/apps/web-ext/src/utils/get-registry-keys.ts
@@ -26,9 +26,10 @@ export function getRegistryKeys(): [
 
   // TODO: トラストアンカーとなる 各 CP issuers ごとでの JWKS の取得方法に変更し安全性を高めるべし
   // https://github.com/originator-profile/profile/issues/2148
+  const kidSet = new Set<string>();
   const keys = registryOps
     .flatMap((op) => op.core.doc.credentialSubject.jwks.keys)
-    .filter((v, i, a) => a.findIndex((t) => t.kid === v.kid) === i);
+    .filter(({ kid }) => !kidSet.has(kid) && kidSet.add(kid));
 
   return [registryOps.flatMap((op) => op.core.doc.issuer), LocalKeys({ keys })];
 }


### PR DESCRIPTION
## 変更内容

CPのJWKが重複して登録されている場合にgetRegistryKeys()関数で重複を排除するように修正しました。
この変更によってv0.1.6との互換性が維持されます。

## 確認手順

https://github.com/originator-profile/profile-share/actions/runs/18548474640?pr=157

からダウンロードできる GitHub Actions のビルドをインストール後

https://www.yomiuri.co.jp/science/20230410-OYT1T50315/ https://www.yomiuri.co.jp/local/ishikawa/news/20241212-OYTNT50206/

などでアクセスしてエラーが出ないことを確認

## レビュアー

shuf -n2 にて選出。
- @Sa-R390
- @r74tech
