### PR TITLE
feat(deprecation): allowedOriginの非推奨警告を追加し、テストを実装

### DIFF
--- a/packages/model/src/allowed-origin.ts
+++ b/packages/model/src/allowed-origin.ts
@@ -15,8 +15,8 @@ export const AllowedOrigin = {
     },
   ],
   description:
-    "@deprecated allowedOrigin は非推奨です。代わりに allowedUrl を使用してください。2026年9月までサポートされます。\n\n" +
-    "Content Attestation によって表明される情報の対象となる [origin](https://www.rfc-editor.org/rfc/rfc6454#section-7)",
+    "@deprecated Content Attestation では allowedOrigin は非推奨です。代わりに allowedUrl を使用してください。2026年9月までサポートされます。\n\n" +
+    "表明される情報の対象となる [origin](https://www.rfc-editor.org/rfc/rfc6454#section-7)",
 } as const satisfies JSONSchema;
 
 export type AllowedOrigin = FromSchema<typeof AllowedOrigin>;

--- a/packages/verify/src/content-attestation/verify-allowed-origin-deprecation.test.ts
+++ b/packages/verify/src/content-attestation/verify-allowed-origin-deprecation.test.ts
@@ -62,7 +62,7 @@ describe("allowedOrigin deprecation 警告", async () => {
     // console.warn が1回呼ばれ、適切な警告メッセージが表示されることを確認
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy).toHaveBeenCalledWith(
-      "[OP Warning] allowedOrigin is deprecated and will be removed after September 2026. " +
+      "[OP Warning] allowedOrigin is deprecated in Content Attestation and will be removed after September 2026. " +
         "Please use allowedUrl instead. " +
         "See: https://docs.originator-profile.org/",
     );

--- a/packages/verify/src/content-attestation/verify-content-attestation.ts
+++ b/packages/verify/src/content-attestation/verify-content-attestation.ts
@@ -32,7 +32,7 @@ async function checkUrlAndOrigin<T extends ContentAttestation>(
 
   if (result.doc.allowedOrigin) {
     console.warn(
-      "[OP Warning] allowedOrigin is deprecated and will be removed after September 2026. " +
+      "[OP Warning] allowedOrigin is deprecated in Content Attestation and will be removed after September 2026. " +
         "Please use allowedUrl instead. " +
         "See: https://docs.originator-profile.org/",
     );


### PR DESCRIPTION
## 変更内容

allowedOrigin指定時にコンソールに警告を表示・説明にもdeprecatedである旨を追加
allowedOrigin指定時コンソールに警告が表示されることを確認するテストを追加

close #135 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

単体のテストを実装してありますので、`pnpm --filter @originator-profile/verify test verify-allowed-origin-deprecation`の実行で確認できます。

## レビュアー

@r74tech
~~@k1o0b1a9~~ 別プロジェクトにアサインされているのでお休み

`shuf -n2 contributors`にて選出させて頂きました。よろしくお願いします