### PR TITLE
Fix registry repository link in README

### DIFF
--- a/packages/cas-generator/README.md
+++ b/packages/cas-generator/README.md
@@ -18,7 +18,7 @@
 
 ## Profile Registry CLI の導入
 
-お手元の環境での作業を前提としています。[registry のリポジトリ](https://github.com/originator-profile/profile-share/tree/main/apps/registry)をご覧ください。
+お手元の環境での作業を前提としています。[registry のリポジトリ](https://github.com/originator-profile/ca-server/tree/main/apps/registry)をご覧ください。
 
 ## ファイルパスの指定
 


### PR DESCRIPTION
Updated the link to the registry repository in the README.

## 変更内容

ca-server リポジトリ分離に伴うリンク切れ修正

## 確認手順

リンク切れでなくなること
