### PR TITLE
type-check 実行時、エラーとなっていた箇所を修正

### DIFF
--- a/packages/verify/src/content-attestation/verify-allowed-origin-deprecation.test.ts
+++ b/packages/verify/src/content-attestation/verify-allowed-origin-deprecation.test.ts
@@ -2,7 +2,15 @@ import { generateKey, LocalKeys } from "@originator-profile/cryptography";
 import { ContentAttestation } from "@originator-profile/model";
 import { signJwtVc } from "@originator-profile/securing-mechanism";
 import { addYears, fromUnixTime, getUnixTime } from "date-fns";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  MockInstance,
+} from "vitest";
 import { opId } from "../helper";
 import { CaVerifier } from "./verify-content-attestation";
 
@@ -13,7 +21,7 @@ const caIssuer = opId.originator;
 
 describe("allowedOrigin deprecation 警告", async () => {
   const issuer = await generateKey();
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: MockInstance<typeof console.warn>;
 
   beforeEach(() => {
     consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- `ConsoleWarnSpy` の型定義を Vitest4.0.0 の型定義に沿ったものに修正しました。

close #177 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

```
cd packages/verify/
pnpm type-check
pnpm --filter @originator-profile/verify test verify-allowed-origin-deprecation
```
type-check 、test ともに通ることをご確認お願いいたします。
また、変更が妥当かどうかもご確認のほどよろしくお願いいたします。

## レビュアー
```
$  shuf -n 2 -e @knokmki612 @kou029w @r74tech @t2ky @mrt0a
@knokmki612
@r74tech
```

@knokmki612 さん、 @r74tech さん　お忙しい中お手数をおかけいたしますが、お手すきの際にご確認のほどよろしくお願いいたします。
また、テストを作成していただいた @t2ky さん もよろしければご確認いただければ幸いです。