### PR TITLE
docs: DCO sign-off 追加方法を記載

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,13 @@
+#!/bin/sh
+# To use this hook, run `git config core.hooksPath .githooks`
+# or copy this file to .git/hooks/prepare-commit-msg in your local repository.
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+  echo "Error: Git user.name and user.email must be configured"
+  exit 1
+fi
+
+git interpret-trailers --in-place --if-exists doNothing --trailer "Signed-off-by: ${NAME} <${EMAIL}>" "$1"

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,37 +6,43 @@
 
 Originator Profile 技術研究組合では、情報の作成者や発信者の真正性を確認可能とするための技術を開発しています。Web の世界をより健全で透明性の高いものとするための技術のグローバルな普及を目指しています。
 
-詳しくはプロジェクトの Web サイトをご覧ください  
+詳しくはプロジェクトの Web サイトをご覧ください
 https://originator-profile.org/
 
-Originator Profile 技術研究組合について  
+Originator Profile 技術研究組合について
 https://originator-profile.org/ja-JP/about/
 
 ## Originator Profile 憲章について
 
-Originator Profile 技術研究組合では基本理念と運用制度の在り方を「Originator Profile 憲章」として定めています。  
+Originator Profile 技術研究組合では基本理念と運用制度の在り方を「Originator Profile 憲章」として定めています。
 https://originator-profile.org/ja-JP/charter/
 
 ## ライセンス
 
 Copyright 2025 Originator Profile Collaborative Innovation Partnership
 
-このプロジェクトは Apache License, Version 2.0（以下「ライセンス」）の下でライセンスされています。このプロジェクトをライセンスに従わない限り利用することはできません。ライセンスの写しは次の場所から入手できます。  
+このプロジェクトは Apache License, Version 2.0（以下「ライセンス」）の下でライセンスされています。このプロジェクトをライセンスに従わない限り利用することはできません。ライセンスの写しは次の場所から入手できます。
 http://www.apache.org/licenses/LICENSE-2.0
 
 法律で要求される場合、または書面による合意がない限り、本ソフトウェアは「現状のまま（AS IS）」で配布され、明示・黙示を問わずいかなる保証もありません。ライセンスで許容される権利および制限については、ライセンスを参照してください。
 
 ## ドキュメント
 
-Originator Profile のアーキテクチャ・仕様や技術情報についてはこちらの Web サイトをご覧ください。  
+Originator Profile のアーキテクチャ・仕様や技術情報についてはこちらの Web サイトをご覧ください。
 https://docs.originator-profile.org/
 
 ## 参加・貢献するには
 
-Originator Profile で開発する技術仕様やソフトウェアに貢献いただくには Developer Certificate of Origin に同意しプルリクエストでサインオフ (Signed-off-by 行) を付与していただくか、Contributor License Agreement に同意していただく必要があります。  
+Originator Profile で開発する技術仕様やソフトウェアに貢献いただくには Developer Certificate of Origin に同意しプルリクエストでサインオフ (Signed-off-by 行) を付与していただくか、Contributor License Agreement に同意していただく必要があります。
 https://docs.originator-profile.org/contributing/
+
+Developer Certificate of Origin への同意方法:
+
+- `git config core.hooksPath .githooks` を実行して、このリポジトリのバージョン管理された Git フックを有効化する（推奨）
+- [.githooks/prepare-commit-msg](.githooks/prepare-commit-msg) を `.git/hooks/prepare-commit-msg` に手動でコピーする
+- 各コミットで `-s` / `--signoff` フラグを付ける
 
 ## お問い合わせ
 
-開発者として参加・貢献いただける場合は「参加・貢献するには」を確認の上で、本 GitHub 上で提案や Pull Request を作成してください。それ以外の一般的なご質問やお問い合わせについては次のフォームをご利用ください。  
+開発者として参加・貢献いただける場合は「参加・貢献するには」を確認の上で、本 GitHub 上で提案や Pull Request を作成してください。それ以外の一般的なご質問やお問い合わせについては次のフォームをご利用ください。
 https://originator-profile.org/ja-JP/contact/

--- a/README.md
+++ b/README.md
@@ -6,37 +6,43 @@
 
 Originator Profile Collaborative Innovation Partnership develops technologies to enable verification of the authenticity of information creators and originators. We aim for the global adoption of technologies to make the web a healthier and more transparent place.
 
-For more details, please visit the project website  
+For more details, please visit the project website
 https://originator-profile.org/
 
-About Originator Profile Collaborative Innovation Partnership  
+About Originator Profile Collaborative Innovation Partnership
 https://originator-profile.org/en-US/about/
 
 ## About Originator Profile Charter
 
-Originator Profile Collaborative Innovation Partnership has established its fundamental principles and operational framework as the “Originator Profile Charter.”  
+Originator Profile Collaborative Innovation Partnership has established its fundamental principles and operational framework as the “Originator Profile Charter.”
 https://originator-profile.org/en-US/charter/
 
 ## License
 
 Copyright 2025 Originator Profile Collaborative Innovation Partnership
 
-This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at:  
+This project is licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with the License. You may obtain a copy of the License at:
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
 ## Documentation
 
-For the architecture, specifications, and technical information of the Originator Profile, please visit this website:  
+For the architecture, specifications, and technical information of the Originator Profile, please visit this website:
 https://docs.originator-profile.org/
 
 ## How to Participate and Contribute
 
-To contribute to the technical specifications or software developed under the Originator Profile project, you must either agree to the Developer Certificate of Origin (by adding a sign-off line, “Signed-off-by”, in your pull request) or agree to the Contributor License Agreement.  
+To contribute to the technical specifications or software developed under the Originator Profile project, you must either agree to the Developer Certificate of Origin (by adding a sign-off line, “Signed-off-by”, in your pull request) or agree to the Contributor License Agreement.
 https://docs.originator-profile.org/contributing/
+
+Methods for agreeing to the Developer Certificate of Origin:
+
+- Run `git config core.hooksPath .githooks` to enable the repository’s version-controlled Git hooks (recommended)
+- Manually copy [.githooks/prepare-commit-msg](.githooks/prepare-commit-msg) to `.git/hooks/prepare-commit-msg`
+- Use the `-s` / `--signoff` flag on each commit
 
 ## Contact
 
-If you wish to participate or contribute as a developer, please review “How to Participate and Contribute” and create proposals or Pull Requests on this GitHub repository. For other general questions or inquiries, please use the following form:  
+If you wish to participate or contribute as a developer, please review “How to Participate and Contribute” and create proposals or Pull Requests on this GitHub repository. For other general questions or inquiries, please use the following form:
 https://originator-profile.org/en-US/contact/


### PR DESCRIPTION
## 変更内容

DCO セットアップ手順を README に記載しました。
https://github.com/originator-profile/profile/issues/2200

## 確認手順

コミット時に自動で sign-off が追加されることを確認しました。

