### PR TITLE
refactor: React RouterをuseRoutesからComponent Routes形式に更新

### DIFF
--- a/apps/web-ext/src/App.tsx
+++ b/apps/web-ext/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
 
   return (
     <Routes>
-      <Route path={paths.root}>
+      <Route path="/">
         <Route index element={<Navigate to="/tab" replace />} />
         <Route path={paths.base}>
           <Route index element={<Base />} />

--- a/apps/web-ext/src/utils/routes.ts
+++ b/apps/web-ext/src/utils/routes.ts
@@ -51,7 +51,6 @@ function getPublParams(ca: ContentAttestation) {
 }
 
 export const paths = {
-  root: "/",
   base: "tab/:tabId",
   org: "org/:contentType/:orgIssuer/:orgSubject",
   publ: "publ/:issuer/:subject",
@@ -60,7 +59,7 @@ export const paths = {
 } as const;
 
 export const routes = {
-  base: route(`${paths.root}${paths.base}`),
+  base: route(`/${paths.base}`),
   org: urlParamsRoute(paths.org, getOrgParams),
   publ: urlParamsRoute(paths.publ, getPublParams),
   site: route(paths.site),


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)
web-ext: path の共通化 9efda1f4

SSoT の観点からパスを paths オブジェクト定数に集約します

Signed-off-by: Kimiaki Kuno <knokmki612@gmail.com>

refactor: React Routerを`useRoutes`からComponent Routes形式に更新 e6708361

- `RouteObject`による設定オブジェクトから`<Routes>/<Route>`のJSX形式に変更
- `overlayExtensionMessenger.onMessage`を`useEffect`内に移動し、適切なクリーンアップ処理を追加
- ネストされたルート構造をより明示的なJSX形式で記述

この変更により、React Routerの推奨パターンに準拠し、コンポーネントのライフサイクル管理が改善されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
Signed-off-by: Kimiaki Kuno <knokmki612@gmail.com>

関連 https://github.com/originator-profile/profile/pull/2137

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
E2Eテスト等により、拡張機能の振る舞いに影響がないこと