### PR TITLE
SP にて WMP が存在する場合でも、存在しないと表示されるケースについて修正

### DIFF
--- a/apps/web-ext/src/pages/SiteProfile.tsx
+++ b/apps/web-ext/src/pages/SiteProfile.tsx
@@ -13,7 +13,7 @@ export default function SiteProfile() {
   if (!siteProfile) return null;
   const op = siteProfile.originators.find(
     (originator) =>
-      originator.core.doc.credentialSubject.id ===
+      originator.media?.doc.credentialSubject.id ===
       siteProfile.credential.doc.issuer,
   );
   const orgPath = op && {


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- SP にて WMP が存在する場合でも、存在しないと表示されるケースについて、正しく表示されるように修正しました。

<img width="528" height="672" alt="image" src="https://github.com/user-attachments/assets/d6056ec3-4b07-4173-b8c1-665db2ad1a9e" />


close #220 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- pnpm dev にて http://localhost:8080/examples/cas-2.html にアクセスし、拡張機能を使用。
- SP にて WMP の情報が表示されていることをご確認ください。
（ #216 のように SP の WMP 部分を削除すると「組織情報が読み取れなかった」旨が表示されます。）

## レビュアー
@knokmki612 さん、　@kou029w さん
お手数をおかけいたしますが、レビューのほどよろしくお願いいたします。