### PR TITLE
chore: GitHub ActionsとRenovateでのSigned-off-byの付与

### DIFF
--- a/.github/actions/format/action.yml
+++ b/.github/actions/format/action.yml
@@ -9,6 +9,7 @@ runs:
       run: |
         git config user.name "bot"
         git config user.email "bot@originator-profile.org"
+        git config core.hooksPath .githooks
       shell: bash
     - name: Commit
       run: |-

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -9,6 +9,7 @@ runs:
       run: |
         git config user.name "bot"
         git config user.email "bot@originator-profile.org"
+        git config core.hooksPath .githooks
       shell: bash
     - name: Commit
       run: |-

--- a/.github/actions/wordpress_format/action.yml
+++ b/.github/actions/wordpress_format/action.yml
@@ -7,6 +7,12 @@ runs:
       run: docker compose exec -w /var/www/html/wp-content/plugins/ca-manager wordpress composer run format
       working-directory: packages/wordpress
       shell: bash
+    - name: setup git config
+      run: |
+        git config user.name "bot"
+        git config user.email "bot@originator-profile.org"
+        git config core.hooksPath .githooks
+      shell: bash
     - name: Commit
       run: |-
         if git commit -am 'bot: format [skip ci]'; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config user.name "${GITHUB_ACTOR}"
+          git config core.hooksPath .githooks
           pnpm exec lerna version --yes "${{ github.event.inputs.version }}"
       - name: Build
         id: build

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:monthly"]
+  "extends": ["config:recommended", "schedule:monthly", ":gitSignOff"]
 }


### PR DESCRIPTION
## 変更内容

GitHub ActionsとRenovateでのSigned-off-byの付与を行うようにしました。

## 確認手順

ブランチを作って、変更を加えてコミットし、Signed-off-byが付与されていることで確認可能
=> https://github.com/originator-profile/originator-profile/pull/223

<img width="786" height="172" alt="image" src="https://github.com/user-attachments/assets/72785c68-f7e2-4287-96b6-705d9e5f1f6e" />
580bf64