### PR TITLE
fix(CaFilter): 初期値が選択肢に存在しない

### DIFF
--- a/apps/web-ext/public/_locales/en/messages.json
+++ b/apps/web-ext/public/_locales/en/messages.json
@@ -5,8 +5,11 @@
   "CaFilter_MainContent": {
     "message": "Main Content"
   },
-  "CaFilter_Other": {
-    "message": "Other"
+  "CaFilter_Article": {
+    "message": "Articles"
+  },
+  "CaFilter_Advertorial": {
+    "message": "Advertorials"
   },
   "CaFilter_Advertisements": {
     "message": "Advertisements"

--- a/apps/web-ext/public/_locales/ja/messages.json
+++ b/apps/web-ext/public/_locales/ja/messages.json
@@ -5,8 +5,11 @@
   "CaFilter_MainContent": {
     "message": "メインコンテンツ"
   },
-  "CaFilter_Other": {
-    "message": "その他コンテンツ"
+  "CaFilter_Article": {
+    "message": "記事"
+  },
+  "CaFilter_Advertorial": {
+    "message": "記事広告"
   },
   "CaFilter_Advertisements": {
     "message": "広告"

--- a/apps/web-ext/src/components/CaFilter.tsx
+++ b/apps/web-ext/src/components/CaFilter.tsx
@@ -17,7 +17,8 @@ type FilterOption = {
 const FILTER_OPTIONS: FilterOption[] = [
   { value: "All", title: _("CaFilter_All") },
   { value: "Main", title: _("CaFilter_MainContent") },
-  { value: "Other", title: _("CaFilter_Other") },
+  { value: "Article", title: _("CaFilter_Article") },
+  { value: "Advertorial", title: _("CaFilter_Advertorial") },
   { value: "OnlineAd", title: _("CaFilter_Advertisements") },
 ];
 

--- a/apps/web-ext/src/components/credentials/Credentials.tsx
+++ b/apps/web-ext/src/components/credentials/Credentials.tsx
@@ -31,7 +31,7 @@ import { isArticleLike } from "./is-articlelike";
 
 export function Credentials(props: CredentialsProps) {
   const [caListType, setCaListType] =
-    useState<Parameters<typeof listCas>[1]>("Article");
+    useState<Parameters<typeof listCas>[1]>("All");
   const { tabId } = useParams<{ tabId: string }>();
 
   const dialog = useModalDialog();

--- a/apps/web-ext/src/components/credentials/cas.ts
+++ b/apps/web-ext/src/components/credentials/cas.ts
@@ -1,6 +1,5 @@
 import { ContentAttestation } from "@originator-profile/model";
 import { VerifiedCas } from "@originator-profile/verify";
-import { isArticleLike } from "./is-articlelike";
 
 /** CAS の列挙 */
 export function listCas<T extends ContentAttestation>(
@@ -19,12 +18,6 @@ export function listCas<T extends ContentAttestation>(
     }
     case "Main": {
       filtered = cas.filter((ca) => ca.main);
-      break;
-    }
-    case "Other": {
-      filtered = cas.filter(
-        (ca) => !ca.main && isArticleLike(ca.attestation.doc.credentialSubject),
-      );
       break;
     }
     case "All":


### PR DESCRIPTION

## 変更内容

(何を・なぜ変更したか)

初期値が `"Article"` だが、CaFilter の選択肢に存在しないので初期状態だと選択肢のどれも選択されていない状態になっている点を解消します。

変更点:

- 初期値を「すべて」に変更
- 「記事」「記事広告」の選択肢を追加
- 『その他コンテンツ」の選択肢を廃止

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
1. `pnpm dev` により dev ページを起動
2. 拡張機能を起動してCaFilter (フィルタリング UI) をクリックし、選択肢の状態を確認する

before

<img width="520" height="640" alt="image" src="https://github.com/user-attachments/assets/a41d54fb-1b10-4a70-9828-394acf04fd93" />

after

<img width="520" height="640" alt="image" src="https://github.com/user-attachments/assets/d1a7f309-c948-4fc1-b482-3f9105957abc" />
