### PR TITLE
複数コンテンツの DigestSriContent が処理できることのテスト

### DIFF
--- a/packages/sign/src/integrity/fetch-and-set-digest-sri.test.ts
+++ b/packages/sign/src/integrity/fetch-and-set-digest-sri.test.ts
@@ -16,6 +16,21 @@ describe("fetchAndSetDigestSri()", () => {
     expect(resource.content).toBeUndefined();
   });
 
+  it("should set digestSRI when digestSRI is missing with content array", async () => {
+    const resource: DigestSriContent = {
+      id: "https://example.com/image.svg",
+      content: [
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjx0aXRsZT5tdWx0aXBsZSBjb250ZW50PC90aXRsZT48L3N2Zz4=",
+      ],
+    };
+
+    await fetchAndSetDigestSri("sha256", resource);
+
+    expect(resource.digestSRI).toBeDefined();
+    expect(resource.content).toBeUndefined();
+  });
+
   it("should set digestSRI when content is missing", async () => {
     const resource: DigestSriContent = {
       id: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

fetchAndSetDigestSri() が複数コンテンツのdigestSRI 値を生成できることを確認するテストを追加します
<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
CIをパスすること