### PR TITLE
組織情報 UI の刷新

### DIFF
--- a/packages/model/src/web-media-profile.ts
+++ b/packages/model/src/web-media-profile.ts
@@ -49,7 +49,24 @@ const subject = {
       },
       required: ["id", "name"],
     },
-    description: { title: "組織に関する説明", type: "string" },
+    description: {
+      title: "組織に関する説明",
+      type: ["string", "object"],
+      properties: {
+        text: {
+          type: "string",
+          description: "Text value.",
+        },
+        encodingFormat: {
+          type: "string",
+          title: "Encoding format",
+          description:
+            "MIME type. Allowed values: 'text/plain' and 'text/html' (only br, p, ol, ul, li allowed).",
+          enum: ["text/plain", "text/html"],
+        },
+      },
+      required: ["text", "encodingFormat"],
+    },
   },
   required: ["id", "type", "url", "name"],
 } as const satisfies JSONSchema;

--- a/packages/sign/src/integrity/fetch-and-set-digest-sri.test.ts
+++ b/packages/sign/src/integrity/fetch-and-set-digest-sri.test.ts
@@ -16,6 +16,21 @@ describe("fetchAndSetDigestSri()", () => {
     expect(resource.content).toBeUndefined();
   });
 
+  it("should set digestSRI when digestSRI is missing with content array", async () => {
+    const resource: DigestSriContent = {
+      id: "https://example.com/image.svg",
+      content: [
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",
+        "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjx0aXRsZT5tdWx0aXBsZSBjb250ZW50PC90aXRsZT48L3N2Zz4=",
+      ],
+    };
+
+    await fetchAndSetDigestSri("sha256", resource);
+
+    expect(resource.digestSRI).toBeDefined();
+    expect(resource.content).toBeUndefined();
+  });
+
   it("should set digestSRI when content is missing", async () => {
     const resource: DigestSriContent = {
       id: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==",

--- a/packages/ui/src/components/Description.tsx
+++ b/packages/ui/src/components/Description.tsx
@@ -1,15 +1,18 @@
 import { twMerge } from "tailwind-merge";
-import useSanitizedHtml from "../utils/use-sanitized-html";
+import useSanitizedHtmlForDescription from "../utils/use-sanitized-html-for-description";
 import { _ } from "../utils/get-message";
 
 type Props = {
   className?: string;
-  description: string;
+  description:
+    | string
+    | { text: string; encodingFormat: "text/plain" | "text/html" };
   onlyBody?: boolean;
 };
 
 function Description({ className, description, onlyBody = false }: Props) {
-  const html = useSanitizedHtml(description);
+  const html = useSanitizedHtmlForDescription(description);
+
   const body = (
     <div
       className="prose prose-xs text-xs break-words"

--- a/packages/ui/src/utils/use-sanitized-html-for-description.ts
+++ b/packages/ui/src/utils/use-sanitized-html-for-description.ts
@@ -1,0 +1,52 @@
+import DOMPurify, { Config as DOMPurifyConfig } from "dompurify";
+
+type DescriptionObject = {
+  text: string;
+  encodingFormat: "text/plain" | "text/html";
+};
+
+// "text/plain" のescape 対応
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const HTML_DESCRIPTION_CONFIG: DOMPurifyConfig = {
+  // 許可するタグをホワイトリストで限定
+  ALLOWED_TAGS: ["br", "p", "ol", "ul", "li"],
+  // 属性は一切許可しない
+  ALLOWED_ATTR: [],
+  // data-* も許可しない
+  ALLOW_DATA_ATTR: false,
+};
+
+/** HTML文字列をサニタイズするカスタムフック for Description */
+export default function useSanitizedHtmlForDescription(
+  dangerousHtml?: string | DescriptionObject,
+): string | undefined {
+  if (dangerousHtml === undefined) return;
+
+  let desc: DescriptionObject;
+
+  if (typeof dangerousHtml === "string") {
+    desc = { text: dangerousHtml, encodingFormat: "text/plain" };
+  } else {
+    desc = dangerousHtml;
+  }
+
+  if (desc.encodingFormat === "text/html") {
+    const parser = new DOMParser();
+    const descriptionDocument = parser.parseFromString(desc.text, "text/html");
+    const res = DOMPurify.sanitize(
+      descriptionDocument.body.innerHTML,
+      HTML_DESCRIPTION_CONFIG,
+    );
+    return res;
+  }
+  // "text/plain"
+  return escapeHtml(desc.text).replace(/\r?\n/g, "<br>");
+}

--- a/packages/ui/src/utils/use-sanitized-html.ts
+++ b/packages/ui/src/utils/use-sanitized-html.ts
@@ -5,15 +5,23 @@ export default function useSanitizedHtml(
   dangerousHtml?: string,
 ): string | undefined {
   if (dangerousHtml === undefined) return;
+
   const parser = new DOMParser();
   const descriptionDocument = parser.parseFromString(
     dangerousHtml,
     "text/html",
   );
+
   DOMPurify.addHook("afterSanitizeAttributes", (node) => {
     if (node.tagName !== "A") return;
     node.setAttribute("target", "_blank");
-    node.setAttribute("rel", "noopener noreferer");
+    node.setAttribute("rel", "noopener noreferrer");
   });
-  return DOMPurify.sanitize(descriptionDocument.body.innerHTML);
+
+  const res = DOMPurify.sanitize(descriptionDocument.body.innerHTML);
+
+  // addHook はグローバル登録されるため、remove しないと複数回登録されてしまう
+  DOMPurify.removeAllHooks();
+
+  return res;
 }


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

組織情報の UI を刷新しました。
- 項目名が「編集ガイドライン」で情報発信ポリシーが表示されていることについて、項目名を「情報発信ポリシー」と正しく表示されるように修正しました。
- タブ表示を廃止しました。
- 組織情報の不要となった表示を廃止しました。
- description が上部に表示されるように修正しました。

close #195 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- apps/web-ext/dev/public/.well-known/sp.json を下記に差し替え。
[sp.zip](https://github.com/user-attachments/files/24049584/sp.zip)
- pnpm dev 後、http://localhost:8080/examples/cas-1.html にアクセス。
- 拡張機能を使用し、組織情報を閲覧。Figma に沿った形で情報が表示されていることをご確認ください。
- また、変更内容が妥当かどうかご確認ください。

UI の変更ですので、 @knokmki612 さん 、（ https://github.com/originator-profile/originator-profile/issues/195#issuecomment-3630767491 こちらの件もご確認いただけますと幸いです。）
シャッフルで、 @r74tech さんにレビュアーを割り当てさせていただきました。
お忙しい中お手数をおかけいたしますが、レビューのほどよろしくお願いいたします。
```
 shuf -n 1 -e @kou029w @mrt0a @YuukiTsuchida @kou-yeung @t2ky @r74tech
@r74tech
```