### PR TITLE
fix(wordpress): fix casing of HtmlTargetIntegrity option

### DIFF
--- a/packages/wordpress/includes/admin.php
+++ b/packages/wordpress/includes/admin.php
@@ -184,7 +184,7 @@ function profile_ca_target_type_field() {
 			style="width: 320px;"
 		>
 		<datalist id="target_integrity_type">
-			<option>HTMLTargetIntegrity</option>
+			<option>HtmlTargetIntegrity</option>
 			<option>TextTargetIntegrity</option>
 			<option>VisibleTextTargetIntegrity</option>
 		</datalist>


### PR DESCRIPTION
選択肢が誤っていましたが正しくは `HtmlTargetIntegrity` (キャメルケース) になります https://docs.originator-profile.org/ja/opb/content-integrity-descriptor/html/

## 確認手順

仕様への適合性