### PR TITLE
docs: update WebsiteProfile schema

### DIFF
--- a/packages/model/src/website-profile.ts
+++ b/packages/model/src/website-profile.ts
@@ -42,7 +42,8 @@ const subject = {
   properties: {
     id: {
       type: "string",
-      title: "Web サイトのオリジン (形式: https://<ホスト名>)",
+      description:
+        "It MUST be the Web site URL. If the same content exists on multiple URLs, specify the most representative URL.",
       format: "uri",
     },
     type: {
@@ -50,12 +51,12 @@ const subject = {
     },
     name: {
       type: "string",
-      title: "Web サイトの名称",
+      description: "The name of the Web site.",
     },
     image: Image,
     description: {
       type: "string",
-      title: "Web サイトの説明",
+      description: "A description of the Web site.",
     },
     allowedOrigin: AllowedOrigin,
   },


### PR DESCRIPTION
## 変更内容

Website Profile の credentialSubject.id がオリジンに限らず、代表的なWebサイトの完全な URL であることを明記しました。

## 確認手順

https://docs.originator-profile.org/en/opb/website-profile/ の記載内容との齟齬が無いこと。
