### PR TITLE
fix(test): OpsVerifier の WMP 配列化に追従

### DIFF
--- a/packages/verify/src/originator-profile-set/verify-ops.test.ts
+++ b/packages/verify/src/originator-profile-set/verify-ops.test.ts
@@ -141,7 +141,7 @@ describe("OPSの検証", async () => {
           signOptions,
         ),
       ],
-      media: await signJwtVc(wmp, authority.privateKey, signOptions),
+      media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
     };
 
     const ops: OriginatorProfileSet = [authorityOp, certifierOp, originatorOp];
@@ -182,11 +182,9 @@ describe("OPSの検証", async () => {
             certifier.publicKey,
           ),
         ],
-        media: verifyResult.create(
-          wmp,
-          originatorOp.media,
-          authority.publicKey,
-        ),
+        media: [
+          verifyResult.create(wmp, originatorOp.media[0], authority.publicKey),
+        ],
       },
     ]);
   });
@@ -206,7 +204,7 @@ describe("OPSの検証", async () => {
           signOptions,
         ),
       ],
-      media: await signJwtVc(wmp, authority.privateKey, signOptions),
+      media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
     };
 
     const ops: OriginatorProfileSet = [authorityOp, certifierOp, originatorOp];
@@ -230,7 +228,9 @@ describe("OPSの検証", async () => {
           certifier.publicKey,
         ),
       ],
-      media: verifyResult.create(wmp, originatorOp.media, authority.publicKey),
+      media: [
+        verifyResult.create(wmp, originatorOp.media[0], authority.publicKey),
+      ],
     });
   });
 
@@ -249,7 +249,7 @@ describe("OPSの検証", async () => {
           signOptions,
         ),
       ],
-      media: await signJwtVc(wmp, authority.privateKey, signOptions),
+      media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
     };
 
     const ops: OriginatorProfileSet = [authorityOp, certifierOp, originatorOp];
@@ -273,7 +273,9 @@ describe("OPSの検証", async () => {
           certifier.publicKey,
         ),
       ],
-      media: verifyResult.create(wmp, originatorOp.media, authority.publicKey),
+      media: [
+        verifyResult.create(wmp, originatorOp.media[0], authority.publicKey),
+      ],
     });
   });
 
@@ -295,7 +297,7 @@ describe("OPSの検証", async () => {
             signOptions,
           ),
         ],
-        media: await signJwtVc(wmp, authority.privateKey, signOptions),
+        media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
       };
 
       const ops: OriginatorProfileSet = [
@@ -323,11 +325,9 @@ describe("OPSの検証", async () => {
             certifier.publicKey,
           ),
         ],
-        media: verifyResult.create(
-          wmp,
-          originatorOp.media,
-          authority.publicKey,
-        ),
+        media: [
+          verifyResult.create(wmp, originatorOp.media[0], authority.publicKey),
+        ],
       });
     } finally {
       vi.useRealTimers();
@@ -352,7 +352,7 @@ describe("OPSの検証", async () => {
             signOptions,
           ),
         ],
-        media: await signJwtVc(wmp, authority.privateKey, signOptions),
+        media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
       };
 
       const ops: OriginatorProfileSet = [
@@ -380,11 +380,9 @@ describe("OPSの検証", async () => {
             certifier.publicKey,
           ),
         ],
-        media: verifyResult.create(
-          wmp,
-          originatorOp.media,
-          authority.publicKey,
-        ),
+        media: [
+          verifyResult.create(wmp, originatorOp.media[0], authority.publicKey),
+        ],
       });
     } finally {
       vi.useRealTimers();
@@ -434,7 +432,7 @@ describe("OPSの検証", async () => {
           signOptions,
         ),
       ],
-      media: await signJwtVc(wmp, authority.privateKey, signOptions),
+      media: [await signJwtVc(wmp, authority.privateKey, signOptions)],
     };
 
     const ops: OriginatorProfileSet = [authorityOp, certifierOp, originatorOp];


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)
https://github.com/originator-profile/originator-profile/pull/272 により検証器の返すWMPの構造が変わったことに追従し、マッチャーが期待通り動作する状態にします

close #

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
`pnpm test` が正常に走りきること