### PR TITLE
Claude Code Review: dependabot & renovate が提出する PR で動作させる

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,3 +36,4 @@ jobs:
             Be constructive and helpful in your feedback.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          allowed_bots: "dependabot[bot],renovate[bot]"


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)
https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md#usage にて示されている allowed_bots オプションを指定して https://github.com/originator-profile/originator-profile/pull/278 で Claude Code Reviews が動作しない点の解消を試みます

close #

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
本PRとしては https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md#usage  を確認頂、無効な形式（未定義のオプションなど）でないこと

マージ後は、 https://github.com/originator-profile/originator-profile/pull/278 で Claude Code Reviews が動作すること