### PR TITLE
add: 画像読み込み失敗した時の対処法をログに出力

### DIFF
--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -10,10 +10,13 @@ type Props = {
   cover?: boolean;
 };
 
-const getDocumentLink = () => {
+const isJa = () => {
   const locale = navigator.language || "en";
-  const ja = locale.startsWith("ja");
-  return `https://docs.originator-profile.org/${ja ? "ja" : "en"}/troubleshooting/image-access-error/`;
+  return locale.startsWith("ja");
+};
+
+const getDocumentLink = () => {
+  return `https://docs.originator-profile.org/${isJa() ? "ja" : "en"}/troubleshooting/image-access-error/`;
 };
 
 const documentLink = getDocumentLink();
@@ -46,9 +49,7 @@ function Image({
         height={height}
         crossOrigin="anonymous"
         onError={(e) => {
-          const locale = navigator.language || "en";
-          const ja = locale.startsWith("ja");
-          const message = ja
+          const message = isJa()
             ? `[Originator Profile] 画像の読み込みに失敗しました: ${e.currentTarget.src}\n対処法: ${documentLink}`
             : `[Originator Profile] Failed to load image: ${e.currentTarget.src}\nTroubleshooting: ${documentLink}`;
           console.error(message);

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -10,6 +10,14 @@ type Props = {
   cover?: boolean;
 };
 
+const getDocumentLink = () => {
+  const locale = navigator.language;
+  const ja = locale.startsWith("ja");
+  return `https://docs.originator-profile.org/${ja ? "ja" : "en"}/troubleshooting/image-access-error/`;
+};
+
+const documentLink = getDocumentLink();
+
 function Image({
   className,
   src,
@@ -40,7 +48,6 @@ function Image({
         onError={(e) => {
           const locale = navigator.language;
           const ja = locale.startsWith("ja");
-          const documentLink = `https://docs.originator-profile.org/${ja ? "ja" : "en"}/troubleshooting/image-access-error/`;
           const message = ja
             ? `[Originator Profile] 画像の読み込みに失敗しました: ${e.currentTarget.src}\n対処法: ${documentLink}`
             : `[Originator Profile] Failed to load image: ${e.currentTarget.src}\nTroubleshooting: ${documentLink}`;

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 const getDocumentLink = () => {
-  const locale = navigator.language;
+  const locale = navigator.language || "en";
   const ja = locale.startsWith("ja");
   return `https://docs.originator-profile.org/${ja ? "ja" : "en"}/troubleshooting/image-access-error/`;
 };
@@ -46,7 +46,7 @@ function Image({
         height={height}
         crossOrigin="anonymous"
         onError={(e) => {
-          const locale = navigator.language;
+          const locale = navigator.language || "en";
           const ja = locale.startsWith("ja");
           const message = ja
             ? `[Originator Profile] 画像の読み込みに失敗しました: ${e.currentTarget.src}\n対処法: ${documentLink}`

--- a/packages/ui/src/components/Image.tsx
+++ b/packages/ui/src/components/Image.tsx
@@ -37,6 +37,15 @@ function Image({
         width={width}
         height={height}
         crossOrigin="anonymous"
+        onError={(e) => {
+          const locale = navigator.language;
+          const ja = locale.startsWith("ja");
+          const documentLink = `https://docs.originator-profile.org/${ja ? "ja" : "en"}/troubleshooting/image-access-error/`;
+          const message = ja
+            ? `[Originator Profile] 画像の読み込みに失敗しました: ${e.currentTarget.src}\n対処法: ${documentLink}`
+            : `[Originator Profile] Failed to load image: ${e.currentTarget.src}\nTroubleshooting: ${documentLink}`;
+          console.error(message);
+        }}
       />
     </figure>
   );


### PR DESCRIPTION
## 変更内容

Imageコンポーネントを利用した画像表示の時にエラーが発生したらログにエラーとその対処用のドキュメントリンクを提示

close https://github.com/originator-profile/profile/issues/1231

## 確認手順

### 1. sp.jsonの更新

sp.jsonの

originators.media の内容を

```
eyJhbGciOiJFUzI1NiIsImtpZCI6ImpKWXM1X0lMZ1VjODE4MEwtcEJQeEJwZ0EzUUM3ZVp1OXdLT2toOW1ZUFUiLCJ0eXAiOiJ2Yytqd3QiLCJjdHkiOiJ2YyJ9.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvbnMvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvbnMvY2lwL3YxIix7IkBsYW5ndWFnZSI6ImphIn1dLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiV2ViTWVkaWFQcm9maWxlIl0sImlzc3VlciI6ImRuczpsb2NhbGhvc3QiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRuczpsb2NhbGhvc3QiLCJ0eXBlIjoiT25saW5lQnVzaW5lc3MiLCJ1cmwiOiJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvIiwibmFtZSI6Ik9yaWdpbmF0b3IgUHJvZmlsZSDmioDooZPnoJTnqbbntYTlkIggKOmWi-eZuueUqCkiLCJsb2dvIjp7ImlkIjoiaHR0cHM6Ly9vcmlnaW5hdG9yLXByb2ZpbGUub3JnL2Zhdmljb24ucyIsImRpZ2VzdFNSSSI6InNoYTI1Ni1GeGR4Rkc2aHVYdEQyVnljaWxhQmpVZDBFaVBibVAwd3dBa1RHQWFXQ1ZZPSJ9LCJjb250YWN0UG9pbnQiOnsiaWQiOiJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvamEtSlAvY29udGFjdC8iLCJuYW1lIjoi44GK5ZWP44GE5ZCI44KP44GbIn0sInByaXZhY3lQb2xpY3kiOnsiaWQiOiJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvamEtSlAvcHJpdmFjeS8iLCJuYW1lIjoi44OX44Op44Kk44OQ44K344O844Od44Oq44K344O8In19LCJpc3MiOiJkbnM6bG9jYWxob3N0Iiwic3ViIjoiZG5zOmxvY2FsaG9zdCIsImlhdCI6MTc2OTA5MDAwMywiZXhwIjoxODAwNjI2MDAzfQ.WR2jBpKL8OC6pXaurEzGW2C6jQhAeEKMzbofLoy9GRofN43QflKwN_Rsabv8QrqmNOExV4WNZg_EfFlwMfEOvw
```

こちらに変更をしてください。
このwmpはロゴの画像を不正なURLにしたものになっています。
手元でwmpに署名をして作成する場合は、`credentialSubject.logo.id` を変更することで貼り付けたwmpと同等のものが作れます。

### 2. ブラウザ起動

`pnpm dev` を実行して拡張機能がインストールされたブラウザを起動してhttp://localhost:8080/examples/cas-1.html を開いてください

### 3. ページ検証を行う

拡張機能を立ち上げてページの検証を行ってください。
ページの検証が失敗している場合は手元のsp.jsonやopsの組み合わせを確認してください。

### 4. エラーログが出力されているか確認

開発者ツールのログタブを開いて

```
[Originator Profile] 画像の読み込みに失敗しました: [画像リンク]
対処法: https://docs.originator-profile.org/ja/troubleshooting/image-access-error/
```
このようなログが出力されているか確認