### PR TITLE
エラーコードから対応ドキュメントへのリンクを追加

### DIFF
--- a/apps/web-ext/src/components/CheckList.tsx
+++ b/apps/web-ext/src/components/CheckList.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@iconify/react";
 import { stringifyWithError } from "@originator-profile/core";
-import { _ } from "@originator-profile/ui";
+import { _, ExternalLink } from "@originator-profile/ui";
 import {
   CasVerificationFailure,
   CasVerifyFailed,
@@ -98,7 +98,13 @@ function DisplayResults({
       {code && (
         <div className="text-gray-700 mb-1">
           <p className="font-bold mb-1">Code</p>
-          <p>{code}</p>
+          <p>
+            <ExternalLink
+              href={`https://docs.originator-profile.org/error-reference/${code}/`}
+            >
+              {code}
+            </ExternalLink>
+          </p>
         </div>
       )}
       {message && (


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- 「詳細情報」画面の検証結果セクションにおいて、エラーコードから対応するドキュメントへのリンクを追加しました。

close #21

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

下記の手順でご確認ください。

- 検証エラー等を発生させているページ等で拡張機能を起動します。
- 「⋮」メニューから「詳細情報」を開き、エラーとなっている項目を確認します。
- 「Code」欄に表示されているエラーコードから、対応するドキュメントへ遷移できることをご確認ください。

例：
- SP が設置されていないページで拡張機能を使用。
- 「⋮」→「詳細情報」→「Site Profile」→「code」からドキュメントへ遷移できることを確認。