### PR TITLE
デコードに成功したが検証まで進まなかったものについて警告マークを表示

### DIFF
--- a/apps/web-ext/src/components/CheckList.tsx
+++ b/apps/web-ext/src/components/CheckList.tsx
@@ -137,18 +137,19 @@ function DetailItem({ label, icon, children, className }: DetailItemProps) {
 }
 
 // value がエラーかどうかを判定し、チェック or キャンセルのアイコンと内容を表示するコンポーネントです。
+// デコード済みではあるが、未検証のものに対しては警告マークを表示します。
 function ResultItem({
   label,
   value,
   showPayload = true,
-  verificationKey = true,
+  isVerified = true,
   children,
   className,
 }: {
   label: string;
   value: unknown;
   showPayload?: boolean;
-  verificationKey?: boolean;
+  isVerified?: boolean;
   children?: React.ReactNode;
   className?: string;
 }) {
@@ -158,7 +159,7 @@ function ResultItem({
   return (
     <DetailItem
       label={label}
-      icon={isError ? "cancel" : verificationKey ? "check" : "null"}
+      icon={isError ? "cancel" : isVerified ? "check" : "null"}
       className={className}
     >
       {isCodeError ? (
@@ -220,7 +221,7 @@ function DisplayOriginators({
       <ResultItem
         label={"Core Profile"}
         value={op.core}
-        verificationKey={"verificationKey" in op.core}
+        isVerified={"verificationKey" in op.core}
         className="mb-2"
       />
       {op.annotations?.map(
@@ -230,7 +231,7 @@ function DisplayOriginators({
             key={index}
             label={`Profile Annotation #${index}`}
             value={annotation}
-            verificationKey={"verificationKey" in annotation}
+            isVerified={"verificationKey" in annotation}
             className="mb-2"
           />
         ),
@@ -242,7 +243,7 @@ function DisplayOriginators({
             key={index}
             label={`Web Media Profile #${index}`}
             value={media}
-            verificationKey={"verificationKey" in media}
+            isVerified={"verificationKey" in media}
             className="mb-2"
           />
         ),


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- デコードに成功したが、検証処理まで進まなかったものについて警告マークを表示するようにしました。
  - CP、PA、WMP のいずれかにてデコードに失敗した際に、その他のものが検証処理まで進まないケースへの対応
  - credentialSubject.id が一致せず、検証処理まで進まないケースへの対応

close #313

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- `pnpm dev` 後、下記を実施してください。
1. CP、PA、WMP のいずれかにてデコードに失敗した際に、その他のものが検証処理まで進まないケース
- `apps/web-ext/dev/public/.well-known/sp.json` の `"core"` の文頭を欠損させ、拡張機能を使用。
- 「⋮」メニューから「詳細情報」を開き、「Site Profile」> 「Originator Profile Set」> 「Originator Profile #○（エラーとなっているもの）」にて CP のみキャンセルマークが表示されており、そのほかの PA、WMP にて警告マークが表示されていることをご確認ください。
2. credentialSubject.id が一致せず、検証処理まで進まないケース
- `apps/web-ext/dev/public/.well-known/sp.json` の `"annotations"` に下記を追加して、拡張機能を使用。
```
eyJhbGciOiJFUzI1NiIsImtpZCI6ImpKWXM1X0lMZ1VjODE4MEwtcEJQeEJwZ0EzUUM3ZVp1OXdLT2toOW1ZUFUiLCJ0eXAiOiJ2Yytqd3QiLCJjdHkiOiJ2YyJ9.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvbnMvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL29yaWdpbmF0b3ItcHJvZmlsZS5vcmcvbnMvY2lwL3YxIix7IkBsYW5ndWFnZSI6ImphLUpQIn1dLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiQ2VydGlmaWNhdGUiXSwiaXNzdWVyIjoiZG5zOmxvY2FsaG9zdCIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZG5zOmxvY2FsaG9zIiwidHlwZSI6IkNlcnRpZmljYXRlUHJvcGVydGllcyIsImRlc2NyaXB0aW9uIjoiRXhhbXBsZSBDZXJ0aWZpY2F0ZSIsImNlcnRpZmljYXRpb25TeXN0ZW0iOnsiaWQiOiJ1cm46dXVpZDpkZTVkNmU4MC0xMGE1LTQwNGYtYjRkMy1lOWYwZTY5MjZhMjEiLCJ0eXBlIjoiQ2VydGlmaWNhdGlvblN5c3RlbSIsIm5hbWUiOiJFeGFtcGxlIENlcnRpZmljYXRpb24gU3lzdGVtIiwiZGVzY3JpcHRpb24iOiJFeGFtcGxlIENlcnRpZmljYXRpb24gU3lzdGVtIERlc2NyaXB0aW9uIn19LCJpc3MiOiJkbnM6bG9jYWxob3N0Iiwic3ViIjoiZG5zOmxvY2FsaG9zIiwiaWF0IjoxNzcyMTcwMDYwLCJleHAiOjE4MDM3MDYwNjB9.gwspZccQIKptKmO2ImOoOAGzv3yeqzpYMS45HnsezDvZR75HOPy-lwJSqPg_GTgM2FkatoAbHo4TiYE4GFPIAQ
```
- 「⋮」メニューから「詳細情報」を開き、「Site Profile」> 「Originator Profile Set」> 「Originator Profile #○（エラーとなっているもの）」にて CP、PA、WMP にて警告マークが表示されていることをご確認ください。