### PR TITLE
既存タブにContent Scriptを注入する機能を追加

### DIFF
--- a/apps/web-ext/src/background.ts
+++ b/apps/web-ext/src/background.ts
@@ -97,7 +97,6 @@ async function injectContentScriptsToExistingTabs(): Promise<void> {
         .executeScript({
           target: { tabId: tab.id, allFrames: cs.all_frames },
           files,
-          injectImmediately: cs.run_at === "document_start",
         })
         .catch(() => {
           // 注入できないページはスキップ
@@ -109,6 +108,8 @@ async function injectContentScriptsToExistingTabs(): Promise<void> {
 }
 
 chrome.runtime.onInstalled.addListener(async ({ reason }) => {
+  if (reason !== "install") return;
+
   await injectContentScriptsToExistingTabs();
 
   const [activeTab] = await chrome.tabs.query({
@@ -118,8 +119,6 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
   if (activeTab?.id !== undefined) {
     requestTabBadgeUpdate(activeTab.id);
   }
-
-  if (reason !== "install") return;
 
   const granted = await chrome.permissions.contains({
     origins: ["<all_urls>"],


### PR DESCRIPTION
## 変更内容

インストール時content scriptが反映されず、リロードしないと検証結果が表示されない問題を修正するため、インストール時開いているタブを取得したのちurlであるものを対象にcontent scriptを追加する実装を追加しました。これによりdev環境におけるインストールされた際のtabs.reloadは不要になったので削除しました。

close #321 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

pnpm devで拡張機能が動作していることを確認した後、

1. http://localhost:8080/examples/cas-1.html などあらかじめ複数検証対象のtabを開いておく
2. chrome://extensions/ にアクセスして拡張機能を削除
3. 右上のデベロッパーモードを有効化
4. 左上のパッケージされていない拡張機能を読み込む
5. apps/web-ext/dist-chromium のディレクトリを選択し、インストール
6. 1で開いたタブの検証結果がリロードしなくても表示できることを確認する
