### PR TITLE
chore: Enable config:best-practices and group:all Renovate presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:monthly", ":gitSignOff"]
+  "extends": [
+    "config:best-practices",
+    "group:all",
+    "schedule:monthly",
+    ":gitSignOff"
+  ]
 }


### PR DESCRIPTION
## Summary

- Replace `config:recommended` + `security:minimumReleaseAgeNpm` with `config:best-practices` (superset)
- Add `group:all` to consolidate all dependency updates into a single PR

## What `config:best-practices` includes

| Preset | Effect |
|---|---|
| `config:recommended` | Base recommended config |
| `security:minimumReleaseAgeNpm` | 3-day wait for npm packages (supply chain protection) |
| `docker:pinDigests` | Pin Docker image digests |
| `helpers:pinGitHubActionDigests` | Pin GitHub Action digests |
| `:pinDevDependencies` | Pin dev dependencies |
| `:configMigration` | Auto-migrate deprecated config options |
| `abandonments:recommended` | Handle abandoned packages |
| `:maintainLockFilesWeekly` | Weekly lock file maintenance |

## Why `group:all`

All dependency updates are grouped into a single PR per schedule cycle, reducing notification noise. Combined with `schedule:monthly`, this means one PR per month with all updates.

## References

- [config:best-practices](https://docs.renovatebot.com/presets-config/)
- [group:all](https://docs.renovatebot.com/presets-group/)
- [security:minimumReleaseAgeNpm](https://docs.renovatebot.com/presets-security/)

https://claude.ai/code/session_015FNxkd16r7uSodwzrXfZHV