### PR TITLE
fix(ci): optimize Playwright cache by switching to version-based key

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,14 +10,25 @@ runs:
         cache: pnpm
         registry-url: "https://registry.npmjs.org"
         scope: "@originator-profile"
+    - name: Get Playwright version
+      id: playwright-version
+      run: echo "version=$(grep -oP \"@playwright/test@\\K[0-9.]+\" pnpm-lock.yaml | head -1)" >> "$GITHUB_OUTPUT"
+      shell: bash
     - name: Restore Playwright cache
+      id: playwright-cache
       uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
-        key: "${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}"
+        key: "${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}"
+        restore-keys: |
+          ${{ runner.os }}-playwright-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash
-    - name: Install browsers and system dependencies
-      run: pnpm --filter @originator-profile/web-ext exec playwright install --with-deps
+    - name: Install Playwright browsers
+      run: pnpm --filter @originator-profile/web-ext exec playwright install
+      shell: bash
+    - name: Install Playwright system dependencies
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      run: pnpm --filter @originator-profile/web-ext exec playwright install-deps
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,23 +12,16 @@ runs:
         scope: "@originator-profile"
     - name: Get Playwright version
       id: playwright-version
-      run: echo "version=$(grep -oP \"@playwright/test@\\K[0-9.]+\" pnpm-lock.yaml | head -1)" >> "$GITHUB_OUTPUT"
+      run: pnpm why --filter @originator-profile/web-ext --json playwright | jq -r '.[].version' | xargs -I{} echo "version={}" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Restore Playwright cache
-      id: playwright-cache
       uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: "${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}"
-        restore-keys: |
-          ${{ runner.os }}-playwright-
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
       shell: bash
-    - name: Install Playwright browsers
-      run: pnpm --filter @originator-profile/web-ext exec playwright install
-      shell: bash
-    - name: Install Playwright system dependencies
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: pnpm --filter @originator-profile/web-ext exec playwright install-deps
+    - name: Install Playwright browsers and system dependencies
+      run: pnpm --filter @originator-profile/web-ext exec playwright install --with-deps
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,13 @@ runs:
         scope: "@originator-profile"
     - name: Get Playwright version
       id: playwright-version
-      run: pnpm why --filter @originator-profile/web-ext --json playwright | jq -r '.[].version' | xargs -I{} echo "version={}" >> "$GITHUB_OUTPUT"
+      run: |
+        PLAYWRIGHT_VERSION=$(pnpm why --filter @originator-profile/web-ext --json playwright | jq -r '.[].version')
+        if [ -z "$PLAYWRIGHT_VERSION" ]; then
+          echo "Error: Failed to detect Playwright version" >&2
+          exit 1
+        fi
+        echo "version=$PLAYWRIGHT_VERSION" >> "$GITHUB_OUTPUT"
       shell: bash
     - name: Restore Playwright cache
       uses: actions/cache@v5


### PR DESCRIPTION
## Summary

- キャッシュキーを`hashFiles('**/pnpm-lock.yaml')`から**Playwrightバージョンベース**に変更。Playwright以外の依存更新（vitest, eslint等）でキャッシュがミスする問題を解消

## Background

Setupステップの`playwright install --with-deps`でタイムアウトが発生するケースがありました。原因分析の結果、以下の2つのパターンが判明：

1. **キャッシュミス時**: ロックファイル全体のハッシュをキャッシュキーに使用しており、Playwrightと無関係な依存更新でもキャッシュがミス → ブラウザ3種のダウンロード + 150以上のシステムパッケージのapt-getインストールで**13分以上**かかる

| 変更点 | Before | After |
|--------|--------|-------|
| キャッシュキー | `hashFiles('**/pnpm-lock.yaml')` | Playwrightバージョン |
| システム依存 | 毎回実行(`--with-deps`) | 変更なし |

## Test plan

- [ ] キャッシュが空の初回実行でブラウザ + システム依存が正常にインストールされることを確認
- [ ] E2Eテストが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)