### PR TITLE
macOSかつPlaywright v1.57+ のE2Eの言語切り替えの修正

### DIFF
--- a/apps/web-ext/e2e/browser-domains.ts
+++ b/apps/web-ext/e2e/browser-domains.ts
@@ -1,0 +1,8 @@
+/** macOS の `defaults write` で言語設定を書き込む対象ドメイン */
+export const BROWSER_DOMAINS = [
+  "org.chromium.Chromium",
+  "com.google.Chrome",
+  "com.google.chrome.for.testing",
+] as const;
+
+export type BrowserDomain = (typeof BROWSER_DOMAINS)[number];

--- a/apps/web-ext/e2e/global-setup.ts
+++ b/apps/web-ext/e2e/global-setup.ts
@@ -3,13 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { platform } from "node:os";
 import { join } from "node:path";
 
-const BROWSER_DOMAINS = [
-  "org.chromium.Chromium",
-  "com.google.Chrome",
-  "com.google.chrome.for.testing",
-] as const;
-
-type BrowserDomain = (typeof BROWSER_DOMAINS)[number];
+import { type BrowserDomain, BROWSER_DOMAINS } from "./browser-domains";
 
 // 現在のブラウザ言語設定を取得
 function getCurrentLanguage(domain: BrowserDomain): string | undefined {

--- a/apps/web-ext/e2e/global-setup.ts
+++ b/apps/web-ext/e2e/global-setup.ts
@@ -3,12 +3,16 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { platform } from "node:os";
 import { join } from "node:path";
 
+const BROWSER_DOMAINS = [
+  "org.chromium.Chromium",
+  "com.google.Chrome",
+  "com.google.chrome.for.testing",
+] as const;
+
+type BrowserDomain = (typeof BROWSER_DOMAINS)[number];
+
 // 現在のブラウザ言語設定を取得
-function getCurrentLanguage(
-  browser: "chromium" | "chrome",
-): string | undefined {
-  const domain =
-    browser === "chromium" ? "org.chromium.Chromium" : "com.google.Chrome";
+function getCurrentLanguage(domain: BrowserDomain): string | undefined {
   try {
     return execSync(`defaults read ${domain} AppleLanguages 2>/dev/null`)
       .toString()
@@ -19,21 +23,19 @@ function getCurrentLanguage(
 }
 
 // ブラウザの言語設定を変更
-function setLanguage(browser: "chromium" | "chrome", locale: string): void {
-  const domain =
-    browser === "chromium" ? "org.chromium.Chromium" : "com.google.Chrome";
+function setLanguage(domain: BrowserDomain, locale: string): void {
   execSync(`defaults write ${domain} AppleLanguages '("${locale}")'`);
 }
 
 // バックアップファイルを保存
 function saveBackup(
-  browser: "chromium" | "chrome",
+  domain: BrowserDomain,
   currentLanguages: string | undefined,
 ): void {
   const tempDir = join(process.cwd(), ".e2e-temp");
   mkdirSync(tempDir, { recursive: true });
 
-  const backupFile = join(tempDir, `${browser}-language-backup.json`);
+  const backupFile = join(tempDir, `${domain}-language-backup.json`);
   writeFileSync(
     backupFile,
     JSON.stringify({ originalLanguages: currentLanguages }),
@@ -42,23 +44,21 @@ function saveBackup(
 
 // ブラウザの言語設定をセットアップ
 function setupBrowserLanguage(
-  browser: "chromium" | "chrome",
+  domain: BrowserDomain,
   targetLocale: string,
 ): void {
-  const browserName = browser === "chromium" ? "Chromium" : "Chrome";
-
-  const currentLanguages = getCurrentLanguage(browser);
+  const currentLanguages = getCurrentLanguage(domain);
   console.log(
-    `現在の${browserName}言語設定:`,
+    `現在の${domain}言語設定:`,
     currentLanguages || "なし（システムデフォルト）",
   );
 
-  saveBackup(browser, currentLanguages);
-  setLanguage(browser, targetLocale);
+  saveBackup(domain, currentLanguages);
+  setLanguage(domain, targetLocale);
 
-  const newLanguages = getCurrentLanguage(browser);
+  const newLanguages = getCurrentLanguage(domain);
   console.log(
-    `${browserName}の言語設定を${targetLocale}に変更しました:`,
+    `${domain}の言語設定を${targetLocale}に変更しました:`,
     newLanguages,
   );
 }
@@ -78,8 +78,9 @@ async function globalSetup() {
     `目標ロケール: ${targetLocale} (LC_ALL=${process.env.LC_ALL || "デフォルト"})`,
   );
 
-  setupBrowserLanguage("chromium", targetLocale);
-  setupBrowserLanguage("chrome", targetLocale);
+  for (const domain of BROWSER_DOMAINS) {
+    setupBrowserLanguage(domain, targetLocale);
+  }
 }
 
 export default globalSetup;

--- a/apps/web-ext/e2e/global-teardown.ts
+++ b/apps/web-ext/e2e/global-teardown.ts
@@ -3,13 +3,7 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { platform } from "node:os";
 import { join } from "node:path";
 
-const BROWSER_DOMAINS = [
-  "org.chromium.Chromium",
-  "com.google.Chrome",
-  "com.google.chrome.for.testing",
-] as const;
-
-type BrowserDomain = (typeof BROWSER_DOMAINS)[number];
+import { type BrowserDomain, BROWSER_DOMAINS } from "./browser-domains";
 
 interface LanguageBackup {
   originalLanguages?: string;
@@ -73,8 +67,8 @@ async function globalTeardown() {
     console.error(`\
 言語設定の復元に失敗しました: ${errorMessage}
 手動で設定を確認してください。
-確認コマンド: 
-  defaults read org.chromium.Chromium AppleLanguages
+確認コマンド:
+${BROWSER_DOMAINS.map((d) => `  defaults read ${d} AppleLanguages`).join("\n")}
 `);
   }
 }

--- a/apps/web-ext/e2e/global-teardown.ts
+++ b/apps/web-ext/e2e/global-teardown.ts
@@ -3,39 +3,39 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { platform } from "node:os";
 import { join } from "node:path";
 
+const BROWSER_DOMAINS = [
+  "org.chromium.Chromium",
+  "com.google.Chrome",
+  "com.google.chrome.for.testing",
+] as const;
+
+type BrowserDomain = (typeof BROWSER_DOMAINS)[number];
+
 interface LanguageBackup {
   originalLanguages?: string;
 }
 
 // ブラウザの言語設定を削除
-function deleteLanguageSetting(browser: "chromium" | "chrome"): void {
-  const domain =
-    browser === "chromium" ? "org.chromium.Chromium" : "com.google.Chrome";
-  const browserName = browser === "chromium" ? "Chromium" : "Chrome";
-
+function deleteLanguageSetting(domain: BrowserDomain): void {
   execSync(`defaults delete ${domain} AppleLanguages 2>/dev/null`);
-  console.log(`${browserName}の言語設定を削除しました（元の状態に復元）`);
+  console.log(`${domain}の言語設定を削除しました（元の状態に復元）`);
 }
 
 // ブラウザの言語設定を復元
 function restoreLanguageSetting(
-  browser: "chromium" | "chrome",
+  domain: BrowserDomain,
   originalLanguages: string,
 ): void {
-  const domain =
-    browser === "chromium" ? "org.chromium.Chromium" : "com.google.Chrome";
-  const browserName = browser === "chromium" ? "Chromium" : "Chrome";
-
   execSync(`defaults write ${domain} AppleLanguages '${originalLanguages}'`);
-  console.log(`${browserName}の言語設定を復元しました`);
+  console.log(`${domain}の言語設定を復元しました`);
 }
 
 // バックアップファイルから設定を復元
 function restoreBrowserLanguage(
-  browser: "chromium" | "chrome",
+  domain: BrowserDomain,
   tempDir: string,
 ): void {
-  const backupFile = join(tempDir, `${browser}-language-backup.json`);
+  const backupFile = join(tempDir, `${domain}-language-backup.json`);
 
   if (!existsSync(backupFile)) {
     return;
@@ -44,9 +44,9 @@ function restoreBrowserLanguage(
   const backup: LanguageBackup = JSON.parse(readFileSync(backupFile, "utf-8"));
 
   if (backup.originalLanguages === undefined) {
-    deleteLanguageSetting(browser);
+    deleteLanguageSetting(domain);
   } else {
-    restoreLanguageSetting(browser, backup.originalLanguages);
+    restoreLanguageSetting(domain, backup.originalLanguages);
   }
 }
 
@@ -60,8 +60,9 @@ async function globalTeardown() {
   const tempDir = join(process.cwd(), ".e2e-temp");
 
   try {
-    restoreBrowserLanguage("chromium", tempDir);
-    restoreBrowserLanguage("chrome", tempDir);
+    for (const domain of BROWSER_DOMAINS) {
+      restoreBrowserLanguage(domain, tempDir);
+    }
 
     // 一時ファイルをクリーンアップ
     if (existsSync(tempDir)) {

--- a/apps/web-ext/e2e/global-teardown.ts
+++ b/apps/web-ext/e2e/global-teardown.ts
@@ -25,10 +25,7 @@ function restoreLanguageSetting(
 }
 
 // バックアップファイルから設定を復元
-function restoreBrowserLanguage(
-  domain: BrowserDomain,
-  tempDir: string,
-): void {
+function restoreBrowserLanguage(domain: BrowserDomain, tempDir: string): void {
   const backupFile = join(tempDir, `${domain}-language-backup.json`);
 
   if (!existsSync(backupFile)) {


### PR DESCRIPTION
Playwright v1.57 で英語 E2E テストの言語切替が効かなくなった問題を修正

## 変更内容

Playwright v1.57.0 でバンドルブラウザが Chromium → Chrome for Testing に変更され、macOS の Bundle ID が org.chromium.Chromium から com.google.chrome.for.testing に変わった。

global-setup.ts / global-teardown.ts の defaults write 対象ドメインに com.google.chrome.for.testing を追加。

close #385

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

macOSをお持ちの方で、Playwright v1.57+の環境で

`LC_ALL=en_US.UTF-8 pnpm exec playwright test --project=en`

が通ることを確認する