### PR TITLE
fix(web-ext): 初回 contentReady スキップを削除しタブ復元時の遅延を解消

### DIFF
--- a/apps/web-ext/src/components/activeTab/frame-readiness-tracker.test.ts
+++ b/apps/web-ext/src/components/activeTab/frame-readiness-tracker.test.ts
@@ -20,26 +20,6 @@ describe("createFrameReadinessTracker", () => {
     vi.useRealTimers();
   });
 
-  describe("初回 contentReady のスキップ", () => {
-    test("メインフレームの初回 contentReady は skip を返す", () => {
-      const result = tracker.handleContentReady(1, 0, true);
-      expect(result).toBe("skip");
-      expect(onRefetch).not.toHaveBeenCalled();
-    });
-
-    test("同タブの2回目のメインフレーム contentReady は pending を返す", () => {
-      tracker.handleContentReady(1, 0, true); // 初回 skip
-      const result = tracker.handleContentReady(1, 0, true);
-      expect(result).toBe("pending");
-    });
-
-    test("異なるタブの初回 contentReady もそれぞれスキップされる", () => {
-      expect(tracker.handleContentReady(1, 0, true)).toBe("skip");
-      expect(tracker.handleContentReady(2, 0, true)).toBe("skip");
-      expect(onRefetch).not.toHaveBeenCalled();
-    });
-  });
-
   describe("表示中タブのフィルタリング", () => {
     test("非表示タブの contentReady は skip を返す", () => {
       const result = tracker.handleContentReady(1, 0, false);
@@ -47,10 +27,16 @@ describe("createFrameReadinessTracker", () => {
     });
   });
 
+  describe("メインフレームの contentReady", () => {
+    test("pending を返す", () => {
+      const result = tracker.handleContentReady(1, 0, true);
+      expect(result).toBe("pending");
+    });
+  });
+
   describe("サブフレームなしのページ", () => {
     test("resolveExpectedFrames でフレームが1つ以下なら即 refetch", () => {
-      tracker.handleContentReady(1, 0, true); // 初回 skip
-      tracker.handleContentReady(1, 0, true); // pending
+      tracker.handleContentReady(1, 0, true);
 
       const result = tracker.resolveExpectedFrames(1, new Set([0]));
       expect(result).toBe("refetch");
@@ -60,8 +46,7 @@ describe("createFrameReadinessTracker", () => {
 
   describe("サブフレームありのページ", () => {
     test("全フレーム ready で refetch", () => {
-      tracker.handleContentReady(1, 0, true); // skip
-      tracker.handleContentReady(1, 0, true); // pending
+      tracker.handleContentReady(1, 0, true);
       tracker.resolveExpectedFrames(1, new Set([0, 1, 2]));
 
       tracker.handleContentReady(1, 1, true); // subframe
@@ -73,8 +58,7 @@ describe("createFrameReadinessTracker", () => {
     });
 
     test("一部フレームのみ ready では pending のまま", () => {
-      tracker.handleContentReady(1, 0, true); // skip
-      tracker.handleContentReady(1, 0, true); // pending
+      tracker.handleContentReady(1, 0, true);
       tracker.resolveExpectedFrames(1, new Set([0, 1, 2]));
 
       const result = tracker.handleContentReady(1, 1, true);
@@ -85,8 +69,7 @@ describe("createFrameReadinessTracker", () => {
 
   describe("タイムアウト", () => {
     test("3秒後に onRefetch が呼ばれる", () => {
-      tracker.handleContentReady(1, 0, true); // skip
-      tracker.handleContentReady(1, 0, true); // pending
+      tracker.handleContentReady(1, 0, true);
       tracker.resolveExpectedFrames(1, new Set([0, 1]));
 
       expect(onRefetch).not.toHaveBeenCalled();
@@ -95,8 +78,7 @@ describe("createFrameReadinessTracker", () => {
     });
 
     test("全フレーム ready 後はタイムアウトで重複呼び出しされない", () => {
-      tracker.handleContentReady(1, 0, true); // skip
-      tracker.handleContentReady(1, 0, true); // pending
+      tracker.handleContentReady(1, 0, true);
       tracker.resolveExpectedFrames(1, new Set([0, 1]));
 
       tracker.handleContentReady(1, 1, true); // refetch
@@ -109,7 +91,6 @@ describe("createFrameReadinessTracker", () => {
 
   describe("レースコンディション対応", () => {
     test("resolveExpectedFrames 前にサブフレームが到着しても蓄積される", () => {
-      tracker.handleContentReady(1, 0, true); // skip
       tracker.handleContentReady(1, 0, true); // pending (expected: null)
 
       // resolveExpectedFrames 前にサブフレームが到着
@@ -125,7 +106,6 @@ describe("createFrameReadinessTracker", () => {
 
   describe("連続遷移", () => {
     test("2回目のメインフレーム ready で1回目がキャンセルされる", () => {
-      tracker.handleContentReady(1, 0, true); // skip
       tracker.handleContentReady(1, 0, true); // 1回目 pending
       tracker.resolveExpectedFrames(1, new Set([0, 1]));
 
@@ -154,16 +134,7 @@ describe("createFrameReadinessTracker", () => {
   });
 
   describe("removeTab", () => {
-    test("閉じたタブの knownTabs がクリアされ次回は初回スキップになる", () => {
-      tracker.handleContentReady(1, 0, true); // 初回 skip → knownTabs に追加
-      tracker.removeTab(1); // クリーンアップ
-
-      // 再度初回スキップになる
-      expect(tracker.handleContentReady(1, 0, true)).toBe("skip");
-    });
-
     test("閉じたタブの pending タイマーがクリアされる", () => {
-      tracker.handleContentReady(1, 0, true); // skip
       tracker.handleContentReady(1, 0, true); // pending (timer set)
 
       tracker.removeTab(1);
@@ -175,7 +146,6 @@ describe("createFrameReadinessTracker", () => {
 
   describe("dispose", () => {
     test("全タイマーがクリアされ onRefetch が呼ばれない", () => {
-      tracker.handleContentReady(1, 0, true); // skip
       tracker.handleContentReady(1, 0, true); // pending (timer set)
 
       tracker.dispose();

--- a/apps/web-ext/src/components/activeTab/frame-readiness-tracker.ts
+++ b/apps/web-ext/src/components/activeTab/frame-readiness-tracker.ts
@@ -34,7 +34,6 @@ export function createFrameReadinessTracker(
   onRefetch: (tabId: number) => void,
 ): FrameReadinessTracker {
   const pendings = new Map<number, PendingFrames>();
-  const knownTabs = new Set<number>();
 
   const clearPending = (tabId: number): void => {
     const pending = pendings.get(tabId);
@@ -63,11 +62,6 @@ export function createFrameReadinessTracker(
     isCurrentTab: boolean,
   ): ReadinessResult => {
     if (!isCurrentTab) return "skip";
-
-    if (frameId === 0 && !knownTabs.has(tabId)) {
-      knownTabs.add(tabId);
-      return "skip";
-    }
 
     if (frameId === 0) {
       clearPending(tabId);
@@ -114,7 +108,6 @@ export function createFrameReadinessTracker(
 
   const removeTab = (tabId: number): void => {
     clearPending(tabId);
-    knownTabs.delete(tabId);
   };
 
   const dispose = (): void => {
@@ -122,7 +115,6 @@ export function createFrameReadinessTracker(
       clearTimeout(pending.timer);
     }
     pendings.clear();
-    knownTabs.clear();
   };
 
   return { handleContentReady, resolveExpectedFrames, removeTab, dispose };

--- a/apps/web-ext/src/components/activeTab/use-navigation-refetch.ts
+++ b/apps/web-ext/src/components/activeTab/use-navigation-refetch.ts
@@ -46,7 +46,7 @@ export function useNavigationRefetch() {
   useEffect(() => {
     const tracker = createFrameReadinessTracker(onRefetch);
 
-    // タブが閉じられたときに knownTabs / pendings をクリーンアップ
+    // タブが閉じられたときに pendings をクリーンアップ
     const removedListener = (tabId: number) => {
       tracker.removeTab(tabId);
     };


### PR DESCRIPTION
## Summary

- FrameReadinessTracker の `knownTabs` による初回 `contentReady` スキップ処理を削除
- タブ復元 (Ctrl+Shift+T) や `chrome://` → Web ページ遷移時に検証結果の表示が約 10 秒遅延する問題を解消

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `frame-readiness-tracker.ts` | `knownTabs` と初回スキップロジックを削除 |
| `frame-readiness-tracker.test.ts` | 初回スキップ関連テスト 3 件を削除、既存テストから不要な初回スキップ呼び出しを除去 |

## Background

> 比較的エッジケースで制約事項でも今後の継続的な改善でも良い部分かとは感じました
> 以下の操作で動画のように閲覧ページの検証結果が反映されない不具合あり:
> 
> [Screencast from 2026-04-10 19-09-49.webm](https://github.com/user-attachments/assets/d83bba8c-b08b-42c5-baf0-a4ab884d285b)
> 
> 1. Firefox起動
> 2. 「閉じたタブを開きなおす」(Ctrl-Shift-T) または「URL貼り付けて移動」
> 3. 閲覧ページの検証結果が反映されない

_Originally posted by @kou029w in https://github.com/originator-profile/originator-profile/issues/377#issuecomment-4222803545_

> 👆画面の前で約10秒待てば解消しました
> ポーリングしているのですね、理解できました
> 
> [Screencast from 2026-04-10 19-25-27.webm](https://github.com/user-attachments/assets/7c571736-3f45-4fde-9e66-c3b479debb20)

_Originally posted by @kou029w in https://github.com/originator-profile/originator-profile/issues/377#issuecomment-4222851470_

> > 👆画面の前で約10秒待てば解消しました
> > ポーリングしている
> 
> この現象ですが、おそらくSWRの再試行処理で表示が更新されていると思われます
> https://swr.vercel.app/ja/docs/error-handling#error-retry
> 
> 動画でも確認できますが、useSiteProfile()フックについては `shouldRetryOnError` 無効化しておりサイトプロファイルは表示されていないことも傍証になっているかと思います
> 
> おそらく https://github.com/originator-profile/originator-profile/pull/377/changes/1f8cd25c7f90681f1664a124eb4f4fc03e9f0806 に始まる、contentReadyメッセージ起点のデータ取得スキップ処理が疑わしく、具体的にはタブの復元については異なるtabIdが割り当てられ、未知のタブへのcontentReadyでのデータ取得スキップが効いているためにDOM描画前に取得失敗した結果のままになってしまっているんじゃないかと思います

_Originally posted by @knokmki612 in https://github.com/originator-profile/originator-profile/issues/377#issuecomment-4234650140_

初回スキップは Side Panel 起動時の IPC 遅延で `contentReady` がリスナー登録後に到達し、不要なリフェッチが発生する懸念から導入された。しかし現在の実装では、初回フェッチ中の SWR キャッシュは空であるため `mutate(filterFn, undefined)` は実質 no-op であり、スキップは不要。

一方、スキップにより以下のケースで `contentReady` によるリフェッチが抑制され、DOM 未準備時の不完全な初回データが表示されたまま残る問題があった:
- タブ復元 (Ctrl+Shift+T) — 新しい tabId が割り当てられるため `knownTabs` に未登録
- `chrome://` → Web ページへのアドレスバー遷移 — Content Script が注入されず `knownTabs` に未登録

## Test plan

- [ ] `pnpm --filter web-ext test` が通ること
- [ ] タブ復元 (Ctrl+Shift+T) → 即座に検証結果が表示される
- [ ] `chrome://settings` → アドレスバーで Web ページに移動 → 即座に検証結果が表示される
- [ ] 通常のページ遷移（同一タブ内）→ Loading 後に新ページの結果が表示される
- [ ] Side Panel 起動 → 既にロード済みのページの検証結果が表示される（二重フェッチは許容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)