### PR TITLE
fix: favicon.png のシンボリックリンクを inspector へ更新 (v0.5)

### DIFF
--- a/public/favicon.png
+++ b/public/favicon.png
@@ -1,1 +1,1 @@
-../apps/web-ext/public/icons/128x128.png
+../apps/inspector/public/icons/128x128.png


### PR DESCRIPTION
## 変更内容

GitHub Actions で `public/favicon.png` の参照が失敗していた問題を解消する (v0.5 向け)。

#391 / #392 で `apps/web-ext` を `apps/inspector` にリネームした際、`public/favicon.png` のシンボリックリンクが旧パス (`../apps/web-ext/public/icons/128x128.png`) を指したままとなり、リンク切れ状態となっていた。シンボリックリンク先を `../apps/inspector/public/icons/128x128.png` に更新する。

main 向けの修正は #395。

## 確認手順

```sh
file public/favicon.png
# => symbolic link to ../apps/inspector/public/icons/128x128.png
```

`broken symbolic link` と表示されないこと、および CI で favicon.png 参照に起因する失敗が再発しないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)