### PR TITLE
fix(demo-page): 画像 URL の /assets/ プレフィックス誤りを修正

### DIFF
--- a/packages/demo-page/en/index.html
+++ b/packages/demo-page/en/index.html
@@ -204,7 +204,7 @@
             "type": "Article",
             "headline": "How to Create a Workspace That Boosts Productivity",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/demo-1.png",
+              "id": "https://demo.exp.originator-profile.org/images/demo-1.png",
               "content": "./public/images/demo-1.png"
             },
             "description": "Demo Page Featuring OPS and CAS from Multiple Originators",
@@ -246,7 +246,7 @@
             "type": "Article",
             "headline": "Soul-Healing Forest Walk",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/demo-2.png",
+              "id": "https://demo.exp.originator-profile.org/images/demo-2.png",
               "content": "./public/images/demo-2.png"
             },
             "description": "Demo Page Featuring OPS and CAS from Multiple Originators",
@@ -288,7 +288,7 @@
             "type": "Advertorial",
             "headline": "10 Must-Have PC Gadgets to Boosts Your Productivity",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/advertorial-demo.png",
+              "id": "https://demo.exp.originator-profile.org/images/advertorial-demo.png",
               "content": "./public/images/advertorial-demo.png"
             },
             "description": "Advertorial Demo",
@@ -327,7 +327,7 @@
             "type": "Article",
             "headline": "A Pause in the Evening City",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/multiple-sri-demo.png",
+              "id": "https://demo.exp.originator-profile.org/images/multiple-sri-demo.png",
               "content": "./public/images/multiple-sri-demo.png"
             },
             "description": "This article is a demo content with multiple images(multiple SRI values).",

--- a/packages/demo-page/ja/index.html
+++ b/packages/demo-page/ja/index.html
@@ -204,7 +204,7 @@
             "type": "Article",
             "headline": "生産性を高めるワークスペースの作り方",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/demo-1.png",
+              "id": "https://demo.exp.originator-profile.org/images/demo-1.png",
               "content": "./public/images/demo-1.png"
             },
             "description": "複数のOPSとCASがあるデモページ",
@@ -246,7 +246,7 @@
             "type": "Article",
             "headline": "心を癒す森の散策",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/demo-2.png",
+              "id": "https://demo.exp.originator-profile.org/images/demo-2.png",
               "content": "./public/images/demo-2.png"
             },
             "description": "複数のOPSとCASがあるデモページ",
@@ -288,7 +288,7 @@
             "type": "Advertorial",
             "headline": "役に立つPCガジェット10選",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/advertorial-demo.png",
+              "id": "https://demo.exp.originator-profile.org/images/advertorial-demo.png",
               "content": "./public/images/advertorial-demo.png"
             },
             "description": "記事広告のデモ",
@@ -327,7 +327,7 @@
             "type": "Article",
             "headline": "夕暮れの街に一息を",
             "image": {
-              "id": "https://demo.exp.originator-profile.org/assets/images/multiple-sri-demo.png",
+              "id": "https://demo.exp.originator-profile.org/images/multiple-sri-demo.png",
               "content": "./public/images/multiple-sri-demo.png"
             },
             "description": "この記事は複数の画像（複数SRI）を含むデモ用コンテンツです。",

--- a/packages/demo-page/sp.json
+++ b/packages/demo-page/sp.json
@@ -56,7 +56,7 @@
         "name": "Demo Page",
         "description": "Demo Page Featuring OPS and CAS from Multiple Originators",
         "image": {
-          "id": "https://demo.exp.originator-profile.org/assets/images/favicon.ico",
+          "id": "https://demo.exp.originator-profile.org/images/favicon.ico",
           "content": "./public/images/favicon.ico"
         },
         "allowedOrigin": [
@@ -83,7 +83,7 @@
         "name": "デモページ",
         "description": "このページは複数のOPSとCASを含むデモページです。",
         "image": {
-          "id": "https://demo.exp.originator-profile.org/assets/images/favicon.ico",
+          "id": "https://demo.exp.originator-profile.org/images/favicon.ico",
           "content": "./public/images/favicon.ico"
         },
         "allowedOrigin": [

--- a/turbo.json
+++ b/turbo.json
@@ -47,11 +47,7 @@
     },
     "demo-page#build": {
       "dependsOn": ["@originator-profile/vite-plugin#build"],
-      "env": [
-        "SIGNING_KEY_DEMO",
-        "SIGNING_KEY_ANOTHER",
-        "SIGNING_KEY_AD"
-      ]
+      "env": ["SIGNING_KEY_DEMO", "SIGNING_KEY_ANOTHER", "SIGNING_KEY_AD"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -44,6 +44,14 @@
         "BASIC_AUTH_CREDENTIALS",
         "REGISTRY_OPS"
       ]
+    },
+    "demo-page#build": {
+      "dependsOn": ["@originator-profile/vite-plugin#build"],
+      "env": [
+        "SIGNING_KEY_DEMO",
+        "SIGNING_KEY_ANOTHER",
+        "SIGNING_KEY_AD"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- PR #388 で新規追加した未署名 CA / WSP の `image.id` URL に誤って `/assets/` プレフィックスが入っており、Vite の `public/` ディレクトリ配信パス (`public/images/*.png` → `/images/*.png`) と一致していなかったため、署名済み CA を参照する拡張機能側で画像表示に失敗していた。`/assets/images/` → `/images/` に修正。
- 併せて `demo-page#build` を `@originator-profile/vite-plugin#build` 依存に登録し、`turbo run build` 時のビルド順序を明示。signing key 系 env もタスク入力に登録して cache の正当性を担保。

`digestSRI` は `image.content` (`./public/images/*`) から計算されるため、URL 修正による digest 変化はありません。

## Test plan

- [ ] `pnpm --filter @originator-profile/vite-plugin build && pnpm --filter demo-page build` が成功する
- [ ] 生成される `dist/client/.well-known/sp.json` の各 site JWT 内 `credentialSubject.image.id` が `/images/...` を指している
- [ ] 生成される `dist/client/{en,ja}/index.html` の `application/cas+json` 内各 entry の `credentialSubject.image.id` が `/images/...` を指している
- [ ] デプロイ後、拡張機能で画像が正常表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)