### PR TITLE
fix(verify): #404 で誤って削除された型アサーションを復元

### DIFF
--- a/packages/verify/src/content-attestation/verify-content-attestation.ts
+++ b/packages/verify/src/content-attestation/verify-content-attestation.ts
@@ -1,5 +1,5 @@
 import { Keys } from "@originator-profile/cryptography";
-import { ContentAttestation } from "@originator-profile/model";
+import { ContentAttestation, type Image } from "@originator-profile/model";
 import {
   JwtVcVerifier,
   VcValidateFailed,
@@ -138,7 +138,9 @@ export function CaVerifier<T extends ContentAttestation>(
     if (urlResult instanceof Error) {
       return urlResult;
     }
-    await verifyImageDigestSri(urlResult.doc.credentialSubject.image);
+    await verifyImageDigestSri(
+      urlResult.doc.credentialSubject.image as Image | undefined,
+    );
     if (urlResult.doc.target) {
       if (urlResult.doc.target.length === 0) {
         return new CaInvalid("Target is empty", urlResult);

--- a/packages/verify/src/originator-profile-set/verify-ops.ts
+++ b/packages/verify/src/originator-profile-set/verify-ops.ts
@@ -28,6 +28,7 @@ import {
   Certificate,
   OpVerificationResult,
   OpsVerificationResult,
+  VerifiedOp,
   VerifiedOps,
 } from "./types";
 
@@ -230,7 +231,7 @@ export function OpsVerifier(
             resultOp,
           );
         }
-        return resultOp;
+        return resultOp as VerifiedOp;
       }),
     );
     if (!isVerifiedOps(resultOps)) {


### PR DESCRIPTION
## Summary

- PR #404 (`fix(deps): pin dependencies`) のコミットに、依存関係のピン留めとは無関係に `packages/verify` 内の型アサーション 2 種を削除する変更が紛れ込み、`main` の `type-check` が失敗していました。
- 該当の型アサーションは TypeScript の型推論上必要なもので、それぞれ削除前の状態に復元します。

### 失敗していたエラー

- `originator-profile/profile/test` ワークフロー: [Run #25900387812](https://github.com/originator-profile/originator-profile/actions/runs/25900387812)
- `@originator-profile/verify#type-check`:
  - `src/content-attestation/verify-content-attestation.ts(141,32)`: `unknown` を `verifyImageDigestSri` に渡している
  - `src/originator-profile-set/verify-ops.ts(233,9)`: `resultOp` を `OpVerificationResult` に割り当てられない

### 原因

`packages/model/src/content-attestation/content-attestation.ts` の `subject` は `z.looseObject({ id, type })` で `image` プロパティを宣言しておらず、`T extends ContentAttestation` 経由のアクセスでは `image` が `unknown` に推論されます。各派生 CA (`ArticleCA` / `AdvertorialCA` / `AdvertisementCA`) はそれぞれ `image: Image.optional()` を上書き定義していますが、`CaVerifier` はベース型 `T extends ContentAttestation` を使うため、`as Image | undefined` のキャストが必要でした。

`OpsVerifier` の map 内では `core` / `annotations` / `media` を `resultOp` リテラルに格納した時点で TypeScript の narrowing が伝播せず、最後の `return resultOp` で `OpVerificationResult` への型変換が通らないため、`as VerifiedOp` のアサーションが必要でした。

## Test plan

- [x] `pnpm run -w type-check` がローカルで通ること（修正前は再現エラー、修正後は 24 tasks すべて成功）
- [x] `pnpm run -w --filter @originator-profile/verify lint` 通過
- [x] `pnpm run -w --filter @originator-profile/verify test` 通過 (119 tests)
- [ ] CI の `originator-profile/profile/test` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)