### PR TITLE
fix(ui): react を peerDependency 化して React 二重ロードを解消

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,6 @@
     "dompurify": "3.4.0",
     "eslint": "10.2.0",
     "eslint-config-originator-profile": "workspace:*",
-    "react": "19.2.5",
     "swr": "2.4.1",
     "tailwind-config-originator-profile": "workspace:*",
     "tailwind-merge": "3.5.0",
@@ -44,6 +43,7 @@
     "vitest": "4.1.4"
   },
   "peerDependencies": {
+    "react": "^19.2.0",
     "tailwindcss": "^4.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,13 +575,16 @@ importers:
 
   packages/ui:
     dependencies:
+      react:
+        specifier: ^19.2.0
+        version: 19.2.6
       tailwindcss:
         specifier: ^4.1.7
         version: 4.2.2
     devDependencies:
       '@iconify/react':
         specifier: 6.0.2
-        version: 6.0.2(react@19.2.5)
+        version: 6.0.2(react@19.2.6)
       '@originator-profile/core':
         specifier: workspace:*
         version: link:../core
@@ -615,12 +618,9 @@ importers:
       eslint-config-originator-profile:
         specifier: workspace:*
         version: link:../eslint-config
-      react:
-        specifier: 19.2.5
-        version: 19.2.5
       swr:
         specifier: 2.4.1
-        version: 2.4.1(react@19.2.5)
+        version: 2.4.1(react@19.2.6)
       tailwind-config-originator-profile:
         specifier: workspace:*
         version: link:../tailwind-config
@@ -8475,10 +8475,6 @@ packages:
       react: '*'
       react-dom: '*'
 
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
@@ -11810,11 +11806,6 @@ snapshots:
   '@iconify/collections@1.0.682':
     dependencies:
       '@iconify/types': 2.0.0
-
-  '@iconify/react@6.0.2(react@19.2.5)':
-    dependencies:
-      '@iconify/types': 2.0.0
-      react: 19.2.5
 
   '@iconify/react@6.0.2(react@19.2.6)':
     dependencies:
@@ -19478,8 +19469,6 @@ snapshots:
       ts-easing: 0.2.0
       tslib: 2.8.1
 
-  react@19.2.5: {}
-
   react@19.2.6: {}
 
   read-package-json-fast@4.0.0:
@@ -20399,12 +20388,6 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
-  swr@2.4.1(react@19.2.5):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.5
-      use-sync-external-store: 1.6.0(react@19.2.5)
-
   swr@2.4.1(react@19.2.6):
     dependencies:
       dequal: 2.0.3
@@ -20953,10 +20936,6 @@ snapshots:
   use-debounce@10.1.1(react@19.2.6):
     dependencies:
       react: 19.2.6
-
-  use-sync-external-store@1.6.0(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:


### PR DESCRIPTION
## Summary

- `apps/inspector` のサイドパネルで `Invalid hook call. Cannot read properties of null (reading 'useRef')` が発生し描画されない不具合を修正。
- 原因: `packages/ui` が `react` を **devDependency** で独自バージョン (`19.2.5`) にピンしていたため、`apps/inspector` が解決する `react@19.2.6` と別実体になり、`@originator-profile/ui` 内で呼ばれる `useRef` の dispatcher と `react-dom` のレンダラーが噛み合わず null 参照していた。
- 修正: `packages/ui/package.json` から `devDependencies.react` を削除し、`peerDependencies.react: "^19.2.0"` を追加。pnpm 11 の `auto-install-peers` により `packages/ui/node_modules/react` もコンシューマ側と同一実体 (`react@19.2.6`) にリンクされる。

## エラー再現時のログ抜粋

```
react.development.js:518 Invalid hook call. ...
Uncaught TypeError: Cannot read properties of null (reading 'useRef')
    at exports.useRef (react.development.js:1260:32)
    at useModalDialog (ModalDialog.tsx:85:15)
    at ReliabilityGuide (ReliabilityGuide.tsx:13:18)
```

## Test plan

- [ ] `pnpm install` 後、`find . -path '*/node_modules/react/package.json' -not -path '*/.pnpm/*' -not -path '*/worktree/*'` の出力で `apps/inspector` と `packages/ui` の `react` シンボリックリンクが同じ `.pnpm/react@19.2.6/...` 実体を指していることを確認
- [ ] `apps/inspector` で `pnpm dev` を実行し、ブラウザ拡張のサイドパネルが描画されること（ReliabilityGuide のモーダルダイアログ「信頼性情報について」も開けること）を確認
- [ ] `packages/ui` の `pnpm test` / `pnpm type-check` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)