### PR TITLE
feat(opvc): 多言語 Website Profile の一括発行をサポート

### DIFF
--- a/packages/opvc/README.md
+++ b/packages/opvc/README.md
@@ -761,11 +761,10 @@ const jwt = await WebsiteProfile.sign(input, privateKey, {
 });
 
 // 多言語の場合: JWT 文字列の配列を返します
-const sites = await WebsiteProfile.sign(
-  [inputJa, inputEn],
-  privateKey,
-  { issuedAt: new Date(), expiredAt: "2027-03-31" },
-);
+const sites = await WebsiteProfile.sign([inputJa, inputEn], privateKey, {
+  issuedAt: new Date(),
+  expiredAt: "2027-03-31",
+});
 ```
 
 ## Development

--- a/packages/opvc/README.md
+++ b/packages/opvc/README.md
@@ -433,8 +433,7 @@ DESCRIPTION
   Website Profile の作成
 
   Website Profile に署名します。
-  入力が単一オブジェクトの場合は JWT を、配列の場合は
-  { "sites": ["<JWT>", ...], "originator": "<OP ID>" } を標準出力に出力します。
+  入力が単一オブジェクトの場合は JWT を、配列の場合は JWT の配列を標準出力に出力します。
   配列入力時は全要素が同一の issuer / credentialSubject.id を持ち、
   @context の @language がそれぞれ異なる必要があります。
 
@@ -747,8 +746,8 @@ const jwt = await ContentAttestation.signByServer(input, {
 
 ### Website Profile の署名 (単一 / 多言語)
 
-`WebsiteProfile.sign()` は単一の未署名 Website Profile を JWT 文字列として署名する他、
-配列を渡すと SiteProfile の `sites` に組み込める `{ sites, originator }` 形式で返します。
+`WebsiteProfile.sign()` は単一の未署名 Website Profile を JWT 文字列として署名するほか、
+配列を渡すと JWT 文字列の配列を返します。これは SiteProfile の `sites` に直接組み込めます。
 配列入力時は全要素が同一の `issuer` / `credentialSubject.id` を持ち、
 `@context` の `@language` がそれぞれ異なる必要があります。
 
@@ -761,8 +760,8 @@ const jwt = await WebsiteProfile.sign(input, privateKey, {
   expiredAt: "2027-03-31",
 });
 
-// 多言語の場合: { sites, originator } を返します
-const { sites, originator } = await WebsiteProfile.sign(
+// 多言語の場合: JWT 文字列の配列を返します
+const sites = await WebsiteProfile.sign(
   [inputJa, inputEn],
   privateKey,
   { issuedAt: new Date(), expiredAt: "2027-03-31" },

--- a/packages/opvc/README.md
+++ b/packages/opvc/README.md
@@ -34,6 +34,7 @@ opvc
 * [`opvc help [COMMAND]`](#opvc-help-command)
 * [`opvc key-gen`](#opvc-key-gen)
 * [`opvc sign`](#opvc-sign)
+* [`opvc wsp:sign`](#opvc-wspsign)
 * [`opvc wsp:unsigned`](#opvc-wspunsigned)
 
 ## `opvc ca:sign`
@@ -414,6 +415,145 @@ FLAG DESCRIPTIONS
 
 _See code: [src/commands/sign.ts](https://github.com/originator-profile/originator-profile/blob/v0.6.0-beta.0/packages/opvc/src/commands/sign.ts)_
 
+## `opvc wsp:sign`
+
+Website Profile の作成
+
+```
+USAGE
+  $ opvc wsp:sign -i <value> --input <filepath> [--issued-at <value>] [--expired-at <value>]
+
+FLAGS
+  -i, --identity=<value>    (required) プライベート鍵のファイルパス
+      --expired-at=<value>  有効期限 (ISO 8601)
+      --input=<filepath>    (required) 入力ファイルのパス (JSON 形式)
+      --issued-at=<value>   発行日時 (ISO 8601)
+
+DESCRIPTION
+  Website Profile の作成
+
+  Website Profile に署名します。
+  入力が単一オブジェクトの場合は JWT を、配列の場合は
+  { "sites": ["<JWT>", ...], "originator": "<OP ID>" } を標準出力に出力します。
+  配列入力時は全要素が同一の issuer / credentialSubject.id を持ち、
+  @context の @language がそれぞれ異なる必要があります。
+
+EXAMPLES
+  $ opvc wsp:sign \
+      -i account-key.example.priv.json \
+      --input website-profile.example.json
+
+  $ opvc wsp:sign \
+      -i account-key.example.priv.json \
+      --input website-profile.multilingual.example.json
+
+FLAG DESCRIPTIONS
+  -i, --identity=<value>  プライベート鍵のファイルパス
+
+    プライベート鍵のファイルパスを渡してください。プライベート鍵は JWK 形式か、PEM base64 でエンコードされた PKCS #8
+    形式にしてください。
+
+  --expired-at=<value>  有効期限 (ISO 8601)
+
+    日付のみの場合、その日の 24:00:00.000 より前まで有効、それ以外の場合、期限切れとなる日付・時刻・秒を指定します。
+
+  --input=<filepath>  入力ファイルのパス (JSON 形式)
+
+    Website Profile (WSP) の例:
+
+    {
+    "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+    "@language": "ja"
+    }
+    ],
+    "type": [
+    "VerifiableCredential",
+    "WebsiteProfile"
+    ],
+    "issuer": "dns:example.com",
+    "credentialSubject": {
+    "id": "https://media.example.com/",
+    "type": "WebSite",
+    "name": "<Webサイトのタイトル>",
+    "description": "<Webサイトの説明>",
+    "image": {
+    "id": "https://media.example.com/image.png",
+    "digestSRI": "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY="
+    },
+    "allowedOrigin": [
+    "https://media.example.com"
+    ]
+    }
+    }
+
+    多言語 Website Profile (配列) の例:
+
+    [
+    {
+    "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+    "@language": "ja"
+    }
+    ],
+    "type": [
+    "VerifiableCredential",
+    "WebsiteProfile"
+    ],
+    "issuer": "dns:example.com",
+    "credentialSubject": {
+    "id": "https://media.example.com/",
+    "type": "WebSite",
+    "name": "<Webサイトのタイトル>",
+    "description": "<Webサイトの説明>",
+    "image": {
+    "id": "https://media.example.com/image.png",
+    "digestSRI": "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY="
+    },
+    "allowedOrigin": [
+    "https://media.example.com"
+    ]
+    }
+    },
+    {
+    "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+    "@language": "en"
+    }
+    ],
+    "type": [
+    "VerifiableCredential",
+    "WebsiteProfile"
+    ],
+    "issuer": "dns:example.com",
+    "credentialSubject": {
+    "id": "https://media.example.com/",
+    "type": "WebSite",
+    "name": "<Website title>",
+    "description": "<Website description>",
+    "image": {
+    "id": "https://media.example.com/image.png",
+    "digestSRI": "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY="
+    },
+    "allowedOrigin": [
+    "https://media.example.com"
+    ]
+    }
+    }
+    ]
+```
+
+_See code: [src/commands/wsp/sign.ts](https://github.com/originator-profile/originator-profile/blob/v0.6.0-beta.0/packages/opvc/src/commands/wsp/sign.ts)_
+
 ## `opvc wsp:unsigned`
 
 未署名 Website Profile の取得
@@ -475,6 +615,71 @@ FLAG DESCRIPTIONS
     ]
     }
     }
+
+    多言語の Website Profile (配列) の例:
+
+    [
+    {
+    "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+    "@language": "ja"
+    }
+    ],
+    "type": [
+    "VerifiableCredential",
+    "WebsiteProfile"
+    ],
+    "issuer": "<OP ID>",
+    "credentialSubject": {
+    "id": "<Web サイトのオリジン (形式: https://<ホスト名>)>",
+    "type": "WebSite",
+    "name": "<Web サイトの名称>",
+    "description": "<Web サイトの説明>",
+    "image": {
+    "id": "<サムネイル画像URL>",
+    "content": [
+    "<コンテンツ (data:// 形式URL)>"
+    ]
+    },
+    "allowedOrigin": [
+    "<Web サイトのオリジン (形式: https://<ホスト名>)>"
+    ]
+    }
+    },
+    {
+    "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+    "@language": "en"
+    }
+    ],
+    "type": [
+    "VerifiableCredential",
+    "WebsiteProfile"
+    ],
+    "issuer": "<OP ID>",
+    "credentialSubject": {
+    "id": "<Web サイトのオリジン (形式: https://<ホスト名>)>",
+    "type": "WebSite",
+    "name": "<Web サイトの名称>",
+    "description": "<Web サイトの説明>",
+    "image": {
+    "id": "<サムネイル画像URL>",
+    "content": [
+    "<コンテンツ (data:// 形式URL)>"
+    ]
+    },
+    "allowedOrigin": [
+    "<Web サイトのオリジン (形式: https://<ホスト名>)>"
+    ]
+    }
+    }
+    ]
 ```
 
 _See code: [src/commands/wsp/unsigned.ts](https://github.com/originator-profile/originator-profile/blob/v0.6.0-beta.0/packages/opvc/src/commands/wsp/unsigned.ts)_
@@ -538,6 +743,30 @@ const jwt = await ContentAttestation.signByServer(input, {
   issuedAt: new Date(),
   expiredAt: "2027-03-31",
 });
+```
+
+### Website Profile の署名 (単一 / 多言語)
+
+`WebsiteProfile.sign()` は単一の未署名 Website Profile を JWT 文字列として署名する他、
+配列を渡すと SiteProfile の `sites` に組み込める `{ sites, originator }` 形式で返します。
+配列入力時は全要素が同一の `issuer` / `credentialSubject.id` を持ち、
+`@context` の `@language` がそれぞれ異なる必要があります。
+
+```ts
+import { WebsiteProfile } from "@originator-profile/opvc";
+
+// 単一の場合: JWT 文字列を返します
+const jwt = await WebsiteProfile.sign(input, privateKey, {
+  issuedAt: new Date(),
+  expiredAt: "2027-03-31",
+});
+
+// 多言語の場合: { sites, originator } を返します
+const { sites, originator } = await WebsiteProfile.sign(
+  [inputJa, inputEn],
+  privateKey,
+  { issuedAt: new Date(), expiredAt: "2027-03-31" },
+);
 ```
 
 ## Development

--- a/packages/opvc/src/commands/wsp/sign.ts
+++ b/packages/opvc/src/commands/wsp/sign.ts
@@ -50,8 +50,7 @@ export class WspSign extends Command {
   static summary = "Website Profile の作成";
   static description = `\
 Website Profile に署名します。
-入力が単一オブジェクトの場合は JWT を、配列の場合は
-{ "sites": ["<JWT>", ...], "originator": "<OP ID>" } を標準出力に出力します。
+入力が単一オブジェクトの場合は JWT を、配列の場合は JWT の配列を標準出力に出力します。
 配列入力時は全要素が同一の issuer / credentialSubject.id を持ち、
 @context の @language がそれぞれ異なる必要があります。`;
   static flags = {

--- a/packages/opvc/src/commands/wsp/sign.ts
+++ b/packages/opvc/src/commands/wsp/sign.ts
@@ -1,0 +1,112 @@
+import { Command, Flags } from "@oclif/core";
+import type { UnsignedWebsiteProfile } from "@originator-profile/model";
+import fs from "node:fs/promises";
+import { expirationDate, privateKey } from "../../flags.ts";
+import { sign } from "../../website-profile.ts";
+
+const exampleWebsiteProfile = {
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    {
+      "@language": "ja",
+    },
+  ],
+  type: ["VerifiableCredential", "WebsiteProfile"],
+  issuer: "dns:example.com",
+  credentialSubject: {
+    id: "https://media.example.com/",
+    type: "WebSite",
+    name: "<Webサイトのタイトル>",
+    description: "<Webサイトの説明>",
+    image: {
+      id: "https://media.example.com/image.png",
+      digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
+    },
+    allowedOrigin: ["https://media.example.com"],
+  },
+} satisfies UnsignedWebsiteProfile;
+
+const exampleMultilingualWebsiteProfile = [
+  exampleWebsiteProfile,
+  {
+    ...exampleWebsiteProfile,
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://originator-profile.org/ns/credentials/v1",
+      "https://originator-profile.org/ns/cip/v1",
+      { "@language": "en" },
+    ],
+    credentialSubject: {
+      ...exampleWebsiteProfile.credentialSubject,
+      name: "<Website title>",
+      description: "<Website description>",
+    },
+  },
+] satisfies UnsignedWebsiteProfile[];
+
+export class WspSign extends Command {
+  static summary = "Website Profile の作成";
+  static description = `\
+Website Profile に署名します。
+入力が単一オブジェクトの場合は JWT を、配列の場合は
+{ "sites": ["<JWT>", ...], "originator": "<OP ID>" } を標準出力に出力します。
+配列入力時は全要素が同一の issuer / credentialSubject.id を持ち、
+@context の @language がそれぞれ異なる必要があります。`;
+  static flags = {
+    identity: privateKey({
+      required: true,
+    }),
+    input: Flags.string({
+      summary: "入力ファイルのパス (JSON 形式)",
+      helpValue: "<filepath>",
+      description: `\
+Website Profile (WSP) の例:
+
+${JSON.stringify(exampleWebsiteProfile, null, "  ")}
+
+多言語 Website Profile (配列) の例:
+
+${JSON.stringify(exampleMultilingualWebsiteProfile, null, "  ")}`,
+      required: true,
+    }),
+    "issued-at": Flags.string({
+      description: "発行日時 (ISO 8601)",
+    }),
+    "expired-at": expirationDate(),
+  };
+  static examples = [
+    `\
+$ <%= config.bin %> <%= command.id %> \\
+    -i account-key.example.priv.json \\
+    --input website-profile.example.json`,
+    `\
+$ <%= config.bin %> <%= command.id %> \\
+    -i account-key.example.priv.json \\
+    --input website-profile.multilingual.example.json`,
+  ];
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(WspSign);
+    const inputBuffer = await fs.readFile(flags.input);
+
+    const input: UnsignedWebsiteProfile | UnsignedWebsiteProfile[] = JSON.parse(
+      inputBuffer.toString(),
+    );
+
+    if (Array.isArray(input)) {
+      const result = await sign(input, flags.identity, {
+        issuedAt: flags["issued-at"],
+        expiredAt: flags["expired-at"],
+      });
+      this.logJson(result);
+    } else {
+      const jwt = await sign(input, flags.identity, {
+        issuedAt: flags["issued-at"],
+        expiredAt: flags["expired-at"],
+      });
+      this.log(jwt);
+    }
+  }
+}

--- a/packages/opvc/src/commands/wsp/unsigned.ts
+++ b/packages/opvc/src/commands/wsp/unsigned.ts
@@ -28,6 +28,27 @@ const exampleWebsiteProfile = {
   },
 } satisfies UnsignedWebsiteProfile;
 
+const exampleMultilingualWebsiteProfile = [
+  {
+    ...exampleWebsiteProfile,
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://originator-profile.org/ns/credentials/v1",
+      "https://originator-profile.org/ns/cip/v1",
+      { "@language": "ja" },
+    ],
+  },
+  {
+    ...exampleWebsiteProfile,
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://originator-profile.org/ns/credentials/v1",
+      "https://originator-profile.org/ns/cip/v1",
+      { "@language": "en" },
+    ],
+  },
+] satisfies UnsignedWebsiteProfile[];
+
 export class WspUnsigned extends Command {
   static summary = "未署名 Website Profile の取得";
   static description = "標準出力に未署名 Website Profile を出力します。";
@@ -38,7 +59,11 @@ export class WspUnsigned extends Command {
       description: `\
 Website Profile の例:
 
-${JSON.stringify(exampleWebsiteProfile, null, "  ")}`,
+${JSON.stringify(exampleWebsiteProfile, null, "  ")}
+
+多言語の Website Profile (配列) の例:
+
+${JSON.stringify(exampleMultilingualWebsiteProfile, null, "  ")}`,
       required: true,
     }),
     "issued-at": Flags.string({
@@ -56,12 +81,17 @@ $ <%= config.bin %> <%= command.id %> \\
     const { flags } = await this.parse(WspUnsigned);
     const inputBuffer = await fs.readFile(flags.input);
 
-    const input: UnsignedWebsiteProfile = JSON.parse(inputBuffer.toString());
-
-    const uwsp = await unsignedWsp(input, {
+    const input: UnsignedWebsiteProfile | UnsignedWebsiteProfile[] = JSON.parse(
+      inputBuffer.toString(),
+    );
+    const options = {
       issuedAt: flags["issued-at"],
       expiredAt: flags["expired-at"],
-    });
+    };
+
+    const uwsp = Array.isArray(input)
+      ? await unsignedWsp(input, options)
+      : await unsignedWsp(input, options);
 
     this.logJson(uwsp);
   }

--- a/packages/opvc/src/commands/wsp/unsigned.ts
+++ b/packages/opvc/src/commands/wsp/unsigned.ts
@@ -84,16 +84,10 @@ $ <%= config.bin %> <%= command.id %> \\
     const input: UnsignedWebsiteProfile | UnsignedWebsiteProfile[] = JSON.parse(
       inputBuffer.toString(),
     );
-    const options = {
+    const uwsp = await unsignedWsp(input, {
       issuedAt: flags["issued-at"],
       expiredAt: flags["expired-at"],
-    };
-    const unsignedWspWithUnion = unsignedWsp as (
-      input: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
-      options: typeof options,
-    ) => ReturnType<typeof unsignedWsp>;
-
-    const uwsp = await unsignedWspWithUnion(input, options);
+    });
 
     this.logJson(uwsp);
   }

--- a/packages/opvc/src/commands/wsp/unsigned.ts
+++ b/packages/opvc/src/commands/wsp/unsigned.ts
@@ -88,10 +88,12 @@ $ <%= config.bin %> <%= command.id %> \\
       issuedAt: flags["issued-at"],
       expiredAt: flags["expired-at"],
     };
+    const unsignedWspWithUnion = unsignedWsp as (
+      input: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+      options: typeof options,
+    ) => ReturnType<typeof unsignedWsp>;
 
-    const uwsp = Array.isArray(input)
-      ? await unsignedWsp(input, options)
-      : await unsignedWsp(input, options);
+    const uwsp = await unsignedWspWithUnion(input, options);
 
     this.logJson(uwsp);
   }

--- a/packages/opvc/src/website-profile.test.ts
+++ b/packages/opvc/src/website-profile.test.ts
@@ -343,7 +343,7 @@ await describe("sign() 戻り値", async () => {
     assert.equal(payload.sub, "https://example.com");
   });
 
-  await test("配列入力はJWT 文字列の配列を返す", async () => {
+  await test("配列入力は JWT 文字列の配列を返す", async () => {
     const result = await sign(
       [baseUwsp("ja"), baseUwsp("en")],
       testPrivateKey,

--- a/packages/opvc/src/website-profile.test.ts
+++ b/packages/opvc/src/website-profile.test.ts
@@ -317,7 +317,7 @@ await describe("unsignedWsp() 配列入力", async () => {
   });
 });
 
-await describe("sign()", async () => {
+await describe("sign() 戻り値", async () => {
   await test("単一入力は JWT 文字列を返す", async () => {
     const jwt = await sign(baseUwsp("ja"), testPrivateKey, {});
 

--- a/packages/opvc/src/website-profile.test.ts
+++ b/packages/opvc/src/website-profile.test.ts
@@ -1,23 +1,27 @@
+import { generateKey } from "@originator-profile/cryptography";
 import type { Jwk, UnsignedWebsiteProfile } from "@originator-profile/model";
 import { BadRequestError } from "http-errors-enhanced";
+import { decodeJwt } from "jose";
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import { sign, unsignedWsp } from "./website-profile.ts";
 
-function createUnsignedWebsiteProfile(): UnsignedWebsiteProfile {
+const { privateKey: testPrivateKey } = await generateKey();
+
+function baseUwsp(language: string): UnsignedWebsiteProfile {
   return {
     "@context": [
       "https://www.w3.org/ns/credentials/v2",
       "https://originator-profile.org/ns/credentials/v1",
       "https://originator-profile.org/ns/cip/v1",
-      { "@language": "ja" },
+      { "@language": language },
     ],
     type: ["VerifiableCredential", "WebsiteProfile"],
     issuer: "dns:example.com",
     credentialSubject: {
       id: "https://example.com",
       type: "WebSite",
-      name: "Example",
+      name: `Example ${language}`,
       image: {
         id: "https://example.com/image.png",
         content: [
@@ -28,6 +32,8 @@ function createUnsignedWebsiteProfile(): UnsignedWebsiteProfile {
     },
   };
 }
+
+const createUnsignedWebsiteProfile = () => baseUwsp("ja-JP");
 
 await describe("unsignedWsp()", async () => {
   await test("有効な UnsignedWebsiteProfile を受け付ける", async () => {
@@ -261,5 +267,82 @@ await describe("sign()", async () => {
       sign(uwsp as unknown as UnsignedWebsiteProfile, {} as Jwk, {}),
       BadRequestError,
     );
+  });
+});
+
+await describe("unsignedWsp() 配列入力", async () => {
+  await test("多言語の配列を受け付け、各要素に iss/sub/iat/exp が付与される", async () => {
+    const uwsps = [baseUwsp("ja"), baseUwsp("en")];
+
+    const result = await unsignedWsp(uwsps, {});
+
+    assert.equal(result.length, 2);
+    for (const item of result) {
+      assert.equal(item.iss, "dns:example.com");
+      assert.equal(item.sub, "https://example.com");
+      assert.ok(item.iat);
+      assert.ok(item.exp);
+    }
+    assert.notEqual(
+      (result[0]["@context"].at(-1) as { "@language": string })["@language"],
+      (result[1]["@context"].at(-1) as { "@language": string })["@language"],
+    );
+  });
+
+  await test("空配列の場合 BadRequestError", async () => {
+    await assert.rejects(unsignedWsp([], {}), BadRequestError);
+  });
+
+  await test("issuer が要素間で異なる場合 BadRequestError", async () => {
+    const ja = baseUwsp("ja");
+    const en = baseUwsp("en");
+    en.issuer = "dns:another.example.com";
+
+    await assert.rejects(unsignedWsp([ja, en], {}), BadRequestError);
+  });
+
+  await test("credentialSubject.id が要素間で異なる場合 BadRequestError", async () => {
+    const ja = baseUwsp("ja");
+    const en = baseUwsp("en");
+    en.credentialSubject.id = "https://another.example.com";
+
+    await assert.rejects(unsignedWsp([ja, en], {}), BadRequestError);
+  });
+
+  await test("@language が重複する場合 BadRequestError", async () => {
+    await assert.rejects(
+      unsignedWsp([baseUwsp("ja"), baseUwsp("ja")], {}),
+      BadRequestError,
+    );
+  });
+});
+
+await describe("sign()", async () => {
+  await test("単一入力は JWT 文字列を返す", async () => {
+    const jwt = await sign(baseUwsp("ja"), testPrivateKey, {});
+
+    assert.equal(typeof jwt, "string");
+    const payload = decodeJwt(jwt);
+    assert.equal(payload.iss, "dns:example.com");
+    assert.equal(payload.sub, "https://example.com");
+  });
+
+  await test("配列入力はJWT 文字列の配列を返す", async () => {
+    const result = await sign(
+      [baseUwsp("ja"), baseUwsp("en")],
+      testPrivateKey,
+      {},
+    );
+
+    assert.equal(result.length, 2);
+
+    const [jaPayload, enPayload] = result.map((jwt) => decodeJwt(jwt));
+    assert.equal(jaPayload.iss, "dns:example.com");
+    assert.equal(enPayload.iss, "dns:example.com");
+
+    const jaContext = (jaPayload as { "@context": unknown[] })["@context"];
+    const enContext = (enPayload as { "@context": unknown[] })["@context"];
+    assert.deepEqual(jaContext.at(-1), { "@language": "ja" });
+    assert.deepEqual(enContext.at(-1), { "@language": "en" });
   });
 });

--- a/packages/opvc/src/website-profile.test.ts
+++ b/packages/opvc/src/website-profile.test.ts
@@ -315,6 +315,22 @@ await describe("unsignedWsp() 配列入力", async () => {
       BadRequestError,
     );
   });
+
+  await test("配列要素に @language がない場合 BadRequestError", async () => {
+    const noLang = {
+      ...baseUwsp("ja"),
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://originator-profile.org/ns/credentials/v1",
+        "https://originator-profile.org/ns/cip/v1",
+      ],
+    } as unknown as UnsignedWebsiteProfile;
+
+    await assert.rejects(
+      unsignedWsp([baseUwsp("ja"), noLang], {}),
+      BadRequestError,
+    );
+  });
 });
 
 await describe("sign() 戻り値", async () => {

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -30,22 +30,22 @@ function assertConsistentSet(uwsps: UnsignedWebsiteProfile[]): void {
   const [head] = uwsps;
   const languages = new Set<string>();
 
-  for (const uwsp of uwsps) {
+  for (const [index, uwsp] of uwsps.entries()) {
     if (uwsp.issuer !== head.issuer) {
       throw new BadRequestError(
-        "All UnsignedWebsiteProfile entries must share the same issuer.",
+        `UnsignedWebsiteProfile entries must share the same issuer (entries[${index}] differs from entries[0]).`,
       );
     }
     if (uwsp.credentialSubject.id !== head.credentialSubject.id) {
       throw new BadRequestError(
-        "All UnsignedWebsiteProfile entries must share the same credentialSubject.id.",
+        `UnsignedWebsiteProfile entries must share the same credentialSubject.id (entries[${index}] differs from entries[0]).`,
       );
     }
 
     const language = extractLanguage(uwsp);
     if (languages.has(language)) {
       throw new BadRequestError(
-        `Duplicate @language "${language}" in UnsignedWebsiteProfile set.`,
+        `Duplicate @language "${language}" at entries[${index}].`,
       );
     }
     languages.add(language);

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -1,24 +1,63 @@
-import { UnsignedWebsiteProfile, type Jwk } from "@originator-profile/model";
-import { fetchAndSetDigestSri, signWsp } from "@originator-profile/sign";
+import { type Jwk, UnsignedWebsiteProfile } from "@originator-profile/model";
+import { signJwtVc } from "@originator-profile/securing-mechanism";
+import { fetchAndSetDigestSri } from "@originator-profile/sign";
 import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import { parseDates, type TimingOptions } from "./timing-options.ts";
 
-/**
- * 未署名 Website Profile の取得
- * @param uwsp 未署名 Website Profile オブジェクト
- * @throws {Error} 入力が UnsignedWebsiteProfile スキーマに適合しない場合
- * @return 未署名 Website Profile オブジェクト
- */
-export async function unsignedWsp(
-  uwsp: UnsignedWebsiteProfile,
-  timingOptions: TimingOptions,
-): Promise<UnsignedWebsiteProfile> {
-  const { issuedAt, expiredAt } = parseDates(timingOptions);
+function extractLanguage(uwsp: UnsignedWebsiteProfile): string {
+  const tail = uwsp["@context"].at(-1);
+  if (
+    tail === undefined ||
+    typeof tail !== "object" ||
+    !("@language" in tail) ||
+    typeof tail["@language"] !== "string"
+  ) {
+    throw new BadRequestError(
+      "Each UnsignedWebsiteProfile must declare @language in @context.",
+    );
+  }
+  return tail["@language"];
+}
 
+function assertConsistentSet(uwsps: UnsignedWebsiteProfile[]): void {
+  if (uwsps.length === 0) {
+    throw new BadRequestError(
+      "At least one UnsignedWebsiteProfile is required.",
+    );
+  }
+
+  const [head] = uwsps;
+  const languages = new Set<string>();
+
+  for (const uwsp of uwsps) {
+    if (uwsp.issuer !== head.issuer) {
+      throw new BadRequestError(
+        "All UnsignedWebsiteProfile entries must share the same issuer.",
+      );
+    }
+    if (uwsp.credentialSubject.id !== head.credentialSubject.id) {
+      throw new BadRequestError(
+        "All UnsignedWebsiteProfile entries must share the same credentialSubject.id.",
+      );
+    }
+
+    const language = extractLanguage(uwsp);
+    if (languages.has(language)) {
+      throw new BadRequestError(
+        `Duplicate @language "${language}" in UnsignedWebsiteProfile set.`,
+      );
+    }
+    languages.add(language);
+  }
+}
+
+async function buildUnsignedWsp(
+  uwsp: UnsignedWebsiteProfile,
+  { issuedAt, expiredAt }: { issuedAt: Date; expiredAt: Date },
+): Promise<UnsignedWebsiteProfile> {
   try {
     UnsignedWebsiteProfile.parse(uwsp);
-
     await fetchAndSetDigestSri("sha256", uwsp.credentialSubject.image);
   } catch (e) {
     throw new BadRequestError((e as Error).message);
@@ -34,22 +73,75 @@ export async function unsignedWsp(
 }
 
 /**
+ * 未署名 Website Profile の取得
+ *
+ * 配列を渡した場合、全要素が同一の `issuer` と `credentialSubject.id` を持ち、
+ * `@context` の `@language` がそれぞれ異なることを検証します。
+ *
+ * @param uwsp 未署名 Website Profile オブジェクト (単一または配列)
+ * @throws {BadRequestError} 配列入力の整合性違反や入力が UnsignedWebsiteProfile スキーマに適合しない場合
+ * @return 未署名 Website Profile (配列入力時は配列)
+ */
+export async function unsignedWsp(
+  uwsp: UnsignedWebsiteProfile,
+  options: TimingOptions,
+): Promise<UnsignedWebsiteProfile>;
+export async function unsignedWsp(
+  uwsp: UnsignedWebsiteProfile[],
+  options: TimingOptions,
+): Promise<UnsignedWebsiteProfile[]>;
+export async function unsignedWsp(
+  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+  options: TimingOptions,
+): Promise<UnsignedWebsiteProfile | UnsignedWebsiteProfile[]> {
+  const { issuedAt, expiredAt } = parseDates(options);
+
+  if (Array.isArray(uwsp)) {
+    assertConsistentSet(uwsp);
+    return Promise.all(
+      uwsp.map((item) => buildUnsignedWsp(item, { issuedAt, expiredAt })),
+    );
+  }
+
+  return buildUnsignedWsp(uwsp, { issuedAt, expiredAt });
+}
+
+/**
  * Website Profile への署名
- * @param uwsp 未署名 Website Profile オブジェクト
+ *
+ * 配列を渡した場合、各要素を個別に署名して JWT 文字列の配列を返します。
+ *
+ * @param uwsp 未署名 Website Profile (単一または配列)
  * @param privateKey プライベート鍵
- * @throws {BadRequestError} 入力が UnsignedWebsiteProfile スキーマに適合しない場合/検証対象のコンテンツが存在しない/コンテンツにアクセスできない/Integrityの計算に失敗
- * @return Website Profile
+ * @throws {BadRequestError} 配列入力の整合性違反や入力が UnsignedWebsiteProfile スキーマに適合しない場合
+ * @return 単一入力時は JWT 文字列、配列入力時は JWT 文字列の配列
  */
 export async function sign(
   uwsp: UnsignedWebsiteProfile,
   privateKey: Jwk,
+  options?: TimingOptions,
+): Promise<string>;
+export async function sign(
+  uwsp: UnsignedWebsiteProfile[],
+  privateKey: Jwk,
+  options?: TimingOptions,
+): Promise<string[]>;
+export async function sign(
+  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+  privateKey: Jwk,
   options: TimingOptions = {},
-): Promise<string> {
+): Promise<string | string[]> {
   const { issuedAt, expiredAt } = parseDates(options);
-  const payload = await unsignedWsp(uwsp, { issuedAt, expiredAt });
 
-  return await signWsp(payload, privateKey, {
-    issuedAt,
-    expiredAt,
-  });
+  if (Array.isArray(uwsp)) {
+    const payloads = await unsignedWsp(uwsp, { issuedAt, expiredAt });
+    return Promise.all(
+      payloads.map((payload) =>
+        signJwtVc(payload, privateKey, { issuedAt, expiredAt }),
+      ),
+    );
+  }
+
+  const payload = await unsignedWsp(uwsp, { issuedAt, expiredAt });
+  return signJwtVc(payload, privateKey, { issuedAt, expiredAt });
 }

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -82,30 +82,25 @@ async function buildUnsignedWsp(
  * @throws {BadRequestError} 配列入力の整合性違反や入力が UnsignedWebsiteProfile スキーマに適合しない場合
  * @return 未署名 Website Profile (配列入力時は配列)
  */
-export async function unsignedWsp(
-  uwsp: UnsignedWebsiteProfile,
+export async function unsignedWsp<
+  U extends UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+>(
+  uwsp: U,
   options: TimingOptions,
-): Promise<UnsignedWebsiteProfile>;
-export async function unsignedWsp(
-  uwsp: UnsignedWebsiteProfile[],
-  options: TimingOptions,
-): Promise<UnsignedWebsiteProfile[]>;
-export async function unsignedWsp(
-  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
-  options: TimingOptions,
-): Promise<UnsignedWebsiteProfile | UnsignedWebsiteProfile[]>;
-export async function unsignedWsp(
-  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
-  options: TimingOptions,
-): Promise<UnsignedWebsiteProfile | UnsignedWebsiteProfile[]> {
+): Promise<U extends unknown[] ? UnsignedWebsiteProfile[] : UnsignedWebsiteProfile> {
+  type Result = U extends unknown[]
+    ? UnsignedWebsiteProfile[]
+    : UnsignedWebsiteProfile;
   const timing = parseDates(options);
 
   if (Array.isArray(uwsp)) {
     assertConsistentSet(uwsp);
-    return Promise.all(uwsp.map((item) => buildUnsignedWsp(item, timing)));
+    return Promise.all(
+      uwsp.map((item) => buildUnsignedWsp(item, timing)),
+    ) as Promise<Result>;
   }
 
-  return buildUnsignedWsp(uwsp, timing);
+  return buildUnsignedWsp(uwsp, timing) as Promise<Result>;
 }
 
 /**
@@ -118,21 +113,14 @@ export async function unsignedWsp(
  * @throws {BadRequestError} 配列入力の整合性違反や入力が UnsignedWebsiteProfile スキーマに適合しない場合
  * @return 単一入力時は JWT 文字列、配列入力時は JWT 文字列の配列
  */
-export async function sign(
-  uwsp: UnsignedWebsiteProfile,
-  privateKey: Jwk,
-  options?: TimingOptions,
-): Promise<string>;
-export async function sign(
-  uwsp: UnsignedWebsiteProfile[],
-  privateKey: Jwk,
-  options?: TimingOptions,
-): Promise<string[]>;
-export async function sign(
-  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+export async function sign<
+  U extends UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+>(
+  uwsp: U,
   privateKey: Jwk,
   options: TimingOptions = {},
-): Promise<string | string[]> {
+): Promise<U extends unknown[] ? string[] : string> {
+  type Result = U extends unknown[] ? string[] : string;
   const timing = parseDates(options);
 
   if (Array.isArray(uwsp)) {
@@ -142,9 +130,9 @@ export async function sign(
         const payload = await buildUnsignedWsp(item, timing);
         return signJwtVc(payload, privateKey, timing);
       }),
-    );
+    ) as Promise<Result>;
   }
 
   const payload = await buildUnsignedWsp(uwsp, timing);
-  return signJwtVc(payload, privateKey, timing);
+  return signJwtVc(payload, privateKey, timing) as Promise<Result>;
 }

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -87,7 +87,9 @@ export async function unsignedWsp<
 >(
   uwsp: U,
   options: TimingOptions,
-): Promise<U extends unknown[] ? UnsignedWebsiteProfile[] : UnsignedWebsiteProfile> {
+): Promise<
+  U extends unknown[] ? UnsignedWebsiteProfile[] : UnsignedWebsiteProfile
+> {
   type Result = U extends unknown[]
     ? UnsignedWebsiteProfile[]
     : UnsignedWebsiteProfile;

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -63,6 +63,9 @@ async function buildUnsignedWsp(
     throw new BadRequestError((e as Error).message);
   }
 
+  // iss/sub/iat/exp は unsignedWsp 単体呼び出しの戻り値で必要となる。
+  // sign 経路では signJwtVc 内の setIssuer/setSubject/setIssuedAt/setExpirationTime
+  // により同値で上書きされるため動作には影響しない。
   return {
     ...uwsp,
     iss: uwsp.issuer,

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -93,17 +93,19 @@ export async function unsignedWsp(
 export async function unsignedWsp(
   uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
   options: TimingOptions,
+): Promise<UnsignedWebsiteProfile | UnsignedWebsiteProfile[]>;
+export async function unsignedWsp(
+  uwsp: UnsignedWebsiteProfile | UnsignedWebsiteProfile[],
+  options: TimingOptions,
 ): Promise<UnsignedWebsiteProfile | UnsignedWebsiteProfile[]> {
-  const { issuedAt, expiredAt } = parseDates(options);
+  const timing = parseDates(options);
 
   if (Array.isArray(uwsp)) {
     assertConsistentSet(uwsp);
-    return Promise.all(
-      uwsp.map((item) => buildUnsignedWsp(item, { issuedAt, expiredAt })),
-    );
+    return Promise.all(uwsp.map((item) => buildUnsignedWsp(item, timing)));
   }
 
-  return buildUnsignedWsp(uwsp, { issuedAt, expiredAt });
+  return buildUnsignedWsp(uwsp, timing);
 }
 
 /**
@@ -131,17 +133,18 @@ export async function sign(
   privateKey: Jwk,
   options: TimingOptions = {},
 ): Promise<string | string[]> {
-  const { issuedAt, expiredAt } = parseDates(options);
+  const timing = parseDates(options);
 
   if (Array.isArray(uwsp)) {
-    const payloads = await unsignedWsp(uwsp, { issuedAt, expiredAt });
+    assertConsistentSet(uwsp);
     return Promise.all(
-      payloads.map((payload) =>
-        signJwtVc(payload, privateKey, { issuedAt, expiredAt }),
-      ),
+      uwsp.map(async (item) => {
+        const payload = await buildUnsignedWsp(item, timing);
+        return signJwtVc(payload, privateKey, timing);
+      }),
     );
   }
 
-  const payload = await unsignedWsp(uwsp, { issuedAt, expiredAt });
-  return signJwtVc(payload, privateKey, { issuedAt, expiredAt });
+  const payload = await buildUnsignedWsp(uwsp, timing);
+  return signJwtVc(payload, privateKey, timing);
 }

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -5,6 +5,9 @@ import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import { parseDates, type TimingOptions } from "./timing-options.ts";
 
+// assertConsistentSet は buildUnsignedWsp 内の UnsignedWebsiteProfile.parse より
+// 前に走るため、@language の存在を fail-fast で確認する。
+// 詳細な構造検証は parse 側が担う。
 function extractLanguage(uwsp: UnsignedWebsiteProfile): string {
   const tail = uwsp["@context"].at(-1);
   if (

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -64,11 +64,11 @@ async function buildUnsignedWsp(
   }
 
   return {
+    ...uwsp,
     iss: uwsp.issuer,
     sub: uwsp.credentialSubject.id,
     iat: getUnixTime(issuedAt),
     exp: getUnixTime(expiredAt),
-    ...uwsp,
   };
 }
 


### PR DESCRIPTION
For https://github.com/originator-profile/ca-server/issues/110

## Summary
- `opvc wsp:sign` / `opvc wsp:unsigned` で WSP の配列入力をサポートし、多言語 (`@context.@language` の異なる) Website Profile を一括発行できるようにします。
- 配列入力時は全要素で同一の `issuer` / `credentialSubject.id` を要求し、`@language` の重複を拒否します。
- `unsignedWsp` の Zod 検証エラーは `BadRequestError` に変換し、`content-attestation.ts` と例外ハンドリングを統一しました。
- 共通の `parseDates` を `timing-options.ts` に切り出し、`website-profile.ts` から再利用しています。

## Test plan
- [x] `pnpm --filter @originator-profile/opvc test` 全 41 ケース通過
- [x] `pnpm --filter @originator-profile/opvc type-check`
- [x] `pnpm --filter @originator-profile/opvc lint`
- [x] `opvc wsp:sign --input <multi-lang.json>` で配列入力時に JWT 配列が出力されることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)