### PR TITLE
feat: 新 Profile Annotation モデルを追加

### DIFF
--- a/apps/inspector/src/pages/Org.tsx
+++ b/apps/inspector/src/pages/Org.tsx
@@ -46,8 +46,9 @@ function Org(props: Props) {
           JSON.stringify([
             a.issuer,
             a.credentialSubject.id,
-            // TODO: https://github.com/originator-profile/originator-profile/pull/415 実装後 `annotation.id` に要修正
-            a.credentialSubject.certificationSystem.id,
+            "annotation" in a.credentialSubject
+              ? a.credentialSubject.annotation.id
+              : a.credentialSubject.certificationSystem.id,
           ]),
       },
     );

--- a/apps/inspector/src/pages/Org.tsx
+++ b/apps/inspector/src/pages/Org.tsx
@@ -1,4 +1,5 @@
 import { selectByLocale } from "@originator-profile/core";
+import { getAnnotationPolicy } from "@originator-profile/ui";
 import { useMemo } from "react";
 import { useParams, useSearchParams } from "react-router";
 import Loading from "../components/Loading";
@@ -46,9 +47,7 @@ function Org(props: Props) {
           JSON.stringify([
             a.issuer,
             a.credentialSubject.id,
-            "annotation" in a.credentialSubject
-              ? a.credentialSubject.annotation.id
-              : a.credentialSubject.certificationSystem.id,
+            getAnnotationPolicy(a.credentialSubject).id,
           ]),
       },
     );

--- a/packages/model/src/certificate/cert-system.ts
+++ b/packages/model/src/certificate/cert-system.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+/**
+ * @deprecated Use {@link ProfileAnnotationPolicy} instead.
+ * The CertificationSystem will be removed in a future version.
+ */
 export const CertificationSystem = z.object({
   id: z.url().describe("Certification system ID"),
   type: z.literal("CertificationSystem"),

--- a/packages/model/src/certificate/certificate-properties.ts
+++ b/packages/model/src/certificate/certificate-properties.ts
@@ -3,6 +3,10 @@ import { Image } from "../image";
 import { OpId } from "../op-id";
 import { CertificationSystem } from "./cert-system";
 
+/**
+ * @deprecated Use {@link ProfileAnnotationProperties} instead.
+ * The CertificateProperties schema will be removed in a future version.
+ */
 export const CertificateProperties = z.object({
   id: OpId.describe("OP ID of the subject"),
   type: z.literal("CertificateProperties"),

--- a/packages/model/src/certificate/certificate-properties.ts
+++ b/packages/model/src/certificate/certificate-properties.ts
@@ -5,7 +5,7 @@ import { CertificationSystem } from "./cert-system";
 
 /**
  * @deprecated Use {@link ProfileAnnotationProperties} instead.
- * The CertificateProperties schema will be removed in a future version.
+ * The CertificateProperties schema will be removed after 2027-01-01.
  */
 export const CertificateProperties = z.object({
   id: OpId.describe("OP ID of the subject"),

--- a/packages/model/src/certificate/certificate.ts
+++ b/packages/model/src/certificate/certificate.ts
@@ -6,7 +6,7 @@ import { CertificateProperties } from "./certificate-properties";
 
 /**
  * @deprecated Use {@link ProfileAnnotation} instead.
- * The Certificate schema will be removed in a future version.
+ * The Certificate schema will be removed after 2027-01-01.
  */
 export const Certificate = z.object({
   "@context": OpCipContext,

--- a/packages/model/src/certificate/certificate.ts
+++ b/packages/model/src/certificate/certificate.ts
@@ -4,6 +4,10 @@ import { DateTimeStamp } from "../date-time-stamp";
 import { OpId } from "../op-id";
 import { CertificateProperties } from "./certificate-properties";
 
+/**
+ * @deprecated Use {@link ProfileAnnotation} instead.
+ * The Certificate schema will be removed in a future version.
+ */
 export const Certificate = z.object({
   "@context": OpCipContext,
   type: z.tuple([z.literal("VerifiableCredential"), z.literal("Certificate")]),

--- a/packages/model/src/certificate/japanese-existence-certificate.ts
+++ b/packages/model/src/certificate/japanese-existence-certificate.ts
@@ -7,7 +7,7 @@ import { CertificationSystem } from "./cert-system";
 
 /**
  * @deprecated Use {@link JapaneseExistencePAProperties} instead.
- * The legacy Certificate-based schema will be removed in a future version.
+ * The legacy Certificate-based schema will be removed after 2027-01-01.
  */
 export const JapaneseExistenceCertificateProperties = z.object({
   id: OpId.describe("OP ID of the subject"),
@@ -27,7 +27,7 @@ export const JapaneseExistenceCertificateProperties = z.object({
 
 /**
  * @deprecated Use {@link JapaneseExistencePA} instead.
- * The legacy Certificate-based schema will be removed in a future version.
+ * The legacy Certificate-based schema will be removed after 2027-01-01.
  */
 export const JapaneseExistenceCertificate = z.looseObject({
   "@context": OpCipContext,

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -14,6 +14,7 @@ export * from "./op-meta";
 export * from "./op-vc";
 export * from "./originator-profile-set";
 export * from "./page";
+export * from "./profile-annotation";
 export * from "./site-profile";
 export * from "./sri";
 export * from "./target/";

--- a/packages/model/src/profile-annotation/index.ts
+++ b/packages/model/src/profile-annotation/index.ts
@@ -1,0 +1,4 @@
+export * from "./japanese-existence-pa";
+export * from "./profile-annotation";
+export * from "./profile-annotation-policy";
+export * from "./profile-annotation-properties";

--- a/packages/model/src/profile-annotation/japanese-existence-pa.ts
+++ b/packages/model/src/profile-annotation/japanese-existence-pa.ts
@@ -3,16 +3,12 @@ import { OpCipContext } from "../context/op-cip-context";
 import { DateTimeStamp } from "../date-time-stamp";
 import { Image } from "../image";
 import { OpId } from "../op-id";
-import { CertificationSystem } from "./cert-system";
+import { ProfileAnnotationPolicy } from "./profile-annotation-policy";
 
-/**
- * @deprecated Use {@link JapaneseExistencePAProperties} instead.
- * The legacy Certificate-based schema will be removed in a future version.
- */
-export const JapaneseExistenceCertificateProperties = z.object({
+export const JapaneseExistencePAProperties = z.object({
   id: OpId.describe("OP ID of the subject"),
   type: z.literal("JP-OrganizationExistenceCertificate"),
-  name: z.string().describe("PA name"),
+  name: z.string().optional().describe("PA name"),
   description: z.string().optional().describe("Description"),
   image: Image.optional(),
   corporateName: z.string().describe("Corporate name"),
@@ -22,24 +18,21 @@ export const JapaneseExistenceCertificateProperties = z.object({
   addressRegion: z.string().describe("Prefecture / State"),
   addressLocality: z.string().describe("City / Municipality"),
   streetAddress: z.string().describe("Street address"),
-  certificationSystem: CertificationSystem,
+  annotation: ProfileAnnotationPolicy,
 });
 
-/**
- * @deprecated Use {@link JapaneseExistencePA} instead.
- * The legacy Certificate-based schema will be removed in a future version.
- */
-export const JapaneseExistenceCertificate = z.looseObject({
+export const JapaneseExistencePA = z.looseObject({
   "@context": OpCipContext,
-  type: z.tuple([z.literal("VerifiableCredential"), z.literal("Certificate")]),
+  type: z.tuple([
+    z.literal("VerifiableCredential"),
+    z.literal("ProfileAnnotation"),
+  ]),
   issuer: OpId,
-  credentialSubject: JapaneseExistenceCertificateProperties,
+  credentialSubject: JapaneseExistencePAProperties,
   validFrom: DateTimeStamp.optional().describe(
     "Validity period start and time",
   ),
   validUntil: DateTimeStamp.optional().describe("Validity period end and time"),
 });
 
-export type JapaneseExistenceCertificate = z.infer<
-  typeof JapaneseExistenceCertificate
->;
+export type JapaneseExistencePA = z.infer<typeof JapaneseExistencePA>;

--- a/packages/model/src/profile-annotation/profile-annotation-policy.ts
+++ b/packages/model/src/profile-annotation/profile-annotation-policy.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const ProfileAnnotationPolicy = z.object({
+  id: z.url().describe("Profile Annotation Policy ID"),
+  type: z.literal("ProfileAnnotationPolicy"),
+  name: z.string().describe("Name of the Profile Annotation Policy"),
+  description: z.string().optional().describe("Description"),
+  ref: z
+    .url()
+    .optional()
+    .describe(
+      "A URL for people to read to find out more about the Profile Annotation Policy.",
+    ),
+});
+
+export type ProfileAnnotationPolicy = z.infer<typeof ProfileAnnotationPolicy>;

--- a/packages/model/src/profile-annotation/profile-annotation-properties.ts
+++ b/packages/model/src/profile-annotation/profile-annotation-properties.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { Image } from "../image";
+import { OpId } from "../op-id";
+import { ProfileAnnotationPolicy } from "./profile-annotation-policy";
+
+export const ProfileAnnotationProperties = z.looseObject({
+  id: OpId.describe("OP ID of the subject"),
+  type: z.string().describe("PA-specific subtype identifier"),
+  name: z.string().optional().describe("PA name"),
+  description: z.string().optional().describe("Description"),
+  image: Image.optional(),
+  annotationScheme: z
+    .array(z.url())
+    .optional()
+    .describe("URIs identifying related PA sets"),
+  annotation: ProfileAnnotationPolicy,
+});
+
+export type ProfileAnnotationProperties = z.infer<
+  typeof ProfileAnnotationProperties
+>;

--- a/packages/model/src/profile-annotation/profile-annotation.ts
+++ b/packages/model/src/profile-annotation/profile-annotation.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { OpCipContext } from "../context/op-cip-context";
+import { DateTimeStamp } from "../date-time-stamp";
+import { OpId } from "../op-id";
+import { ProfileAnnotationProperties } from "./profile-annotation-properties";
+
+export const ProfileAnnotation = z.looseObject({
+  "@context": OpCipContext,
+  type: z.tuple([
+    z.literal("VerifiableCredential"),
+    z.literal("ProfileAnnotation"),
+  ]),
+  issuer: OpId,
+  validFrom: DateTimeStamp.optional().describe(
+    "Validity period start and time",
+  ),
+  validUntil: DateTimeStamp.optional().describe("Validity period end and time"),
+  credentialSubject: ProfileAnnotationProperties,
+});
+
+export type ProfileAnnotation = z.infer<typeof ProfileAnnotation>;

--- a/packages/sign/src/sign-vc/certificate.test.ts
+++ b/packages/sign/src/sign-vc/certificate.test.ts
@@ -9,10 +9,10 @@ import { decodeJwt, decodeProtectedHeader } from "jose";
 import { describe, expect, test } from "vitest";
 
 describe("Certificate", () => {
-  test("sign a JICDAQ certificate", async () => {
+  test("sign an AdvertisingQualityCertificate", async () => {
     const issuedAt = new Date();
     const expiredAt = addYears(new Date(), 10);
-    const jicdaq: Certificate = {
+    const adCert: Certificate = {
       "@context": [
         "https://www.w3.org/ns/credentials/v2",
         "https://originator-profile.org/ns/credentials/v1",
@@ -25,34 +25,34 @@ describe("Certificate", () => {
         id: "dns:pa-holder.example.jp",
         type: "CertificateProperties",
         description:
-          "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。第三者機関（日本ABC協会）による検証を経て、本認証を取得しました。",
+          "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。",
         image: {
           id: "https://example.com/certification-mark.svg",
           digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
         },
-        certifier: "一般社団法人 デジタル広告品質認証機構",
-        verifier: "日本ABC協会",
+        certifier: "架空広告認証センター",
+        verifier: "架空広告監査機構",
         certificationSystem: {
           id: "urn:uuid:2a12a385-fd1c-48e6-acd8-176c0c5e95ea",
           type: "CertificationSystem",
-          name: "JICDAQ ブランドセーフティ第三者検証",
+          name: "架空広告認証センター ブランドセーフティ認証",
           description: "blah blah blah",
-          ref: "https://www.jicdaq.or.jp/",
+          ref: "https://adcert.exp.originator-profile.org/",
         },
       },
       validFrom: "2022-03-31T15:00:00Z",
       validUntil: "2024-03-31T14:59:59Z",
     };
     const { publicKey, privateKey } = await generateKey();
-    const jwt = await signJwtVc(jicdaq, privateKey, { issuedAt, expiredAt });
+    const jwt = await signJwtVc(adCert, privateKey, { issuedAt, expiredAt });
     expect(decodeProtectedHeader(jwt).kid).toBe(publicKey.kid);
     const valid = decodeJwt(jwt);
     expect(valid).toStrictEqual({
-      iss: jicdaq.issuer,
+      iss: adCert.issuer,
       iat: getUnixTime(issuedAt),
       exp: getUnixTime(expiredAt),
-      sub: jicdaq.credentialSubject.id,
-      ...jicdaq,
+      sub: adCert.credentialSubject.id,
+      ...adCert,
     });
   });
 

--- a/packages/sign/src/sign-vc/profile-annotation.test.ts
+++ b/packages/sign/src/sign-vc/profile-annotation.test.ts
@@ -1,0 +1,98 @@
+import { generateKey } from "@originator-profile/cryptography";
+import {
+  JapaneseExistencePA,
+  ProfileAnnotation,
+} from "@originator-profile/model";
+import { signJwtVc } from "@originator-profile/securing-mechanism";
+import { addYears, getUnixTime } from "date-fns";
+import { decodeJwt, decodeProtectedHeader } from "jose";
+import { describe, expect, test } from "vitest";
+
+describe("ProfileAnnotation", () => {
+  test("sign an AdvertisingQualityCertificate PA", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const adCert: ProfileAnnotation = {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://originator-profile.org/ns/credentials/v1",
+        "https://originator-profile.org/ns/cip/v1",
+        { "@language": "ja" },
+      ],
+      type: ["VerifiableCredential", "ProfileAnnotation"],
+      issuer: "dns:adcert.exp.originator-profile.org",
+      credentialSubject: {
+        id: "dns:pa-holder.example.jp",
+        type: "AdvertisingQualityCertificate",
+        verifier: "架空広告監査機構",
+        annotation: {
+          id: "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92",
+          type: "ProfileAnnotationPolicy",
+          name: "架空広告認証センター ブランドセーフティ認証",
+          description:
+            "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。",
+          ref: "https://adcert.exp.originator-profile.org/",
+        },
+      },
+      validFrom: "2022-03-31T15:00:00Z",
+      validUntil: "2024-03-31T14:59:59Z",
+    };
+    const { publicKey, privateKey } = await generateKey();
+    const jwt = await signJwtVc(adCert, privateKey, { issuedAt, expiredAt });
+    expect(decodeProtectedHeader(jwt).kid).toBe(publicKey.kid);
+    const valid = decodeJwt(jwt);
+    expect(valid).toStrictEqual({
+      iss: adCert.issuer,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+      sub: adCert.credentialSubject.id,
+      ...adCert,
+    });
+  });
+
+  test("sign a Japanese existence PA", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const pa: JapaneseExistencePA = {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://originator-profile.org/ns/credentials/v1",
+        "https://originator-profile.org/ns/cip/v1",
+        { "@language": "ja" },
+      ],
+      type: ["VerifiableCredential", "ProfileAnnotation"],
+      issuer: "dns:pa-issuer.example.org",
+      credentialSubject: {
+        id: "dns:pa-holder.example.jp",
+        type: "JP-OrganizationExistenceCertificate",
+        name: "○○新聞社 (※開発用サンプル)",
+        corporateName: "○○新聞社 (※開発用サンプル)",
+        corporateNumber: "0000000000000",
+        postalCode: "000-0000",
+        addressCountry: "JP",
+        addressRegion: "東京都",
+        addressLocality: "千代田区",
+        streetAddress: "○○○",
+        annotation: {
+          id: "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
+          type: "ProfileAnnotationPolicy",
+          name: "架空組織実在性検証局 実在証明",
+          description:
+            "この組織は、法人登記の照会等により組織が実在していることが確認できました。",
+          ref: "https://ovac.exp.originator-profile.org/",
+        },
+      },
+    };
+    const { publicKey, privateKey } = await generateKey();
+    const jwt = await signJwtVc(pa, privateKey, { issuedAt, expiredAt });
+    expect(decodeProtectedHeader(jwt).kid).toBe(publicKey.kid);
+    const valid = decodeJwt(jwt);
+    expect(valid).toStrictEqual({
+      iss: pa.issuer,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+      sub: pa.credentialSubject.id,
+      ...pa,
+    });
+  });
+});

--- a/packages/ui/src/components/profileAnnotation/CertificateDetail.tsx
+++ b/packages/ui/src/components/profileAnnotation/CertificateDetail.tsx
@@ -1,10 +1,10 @@
 import { Icon } from "@iconify/react";
-import type { CertificationSystem } from "@originator-profile/model";
 import { VerifiedVc } from "@originator-profile/securing-mechanism";
 import { Certificate, VerifiedOps } from "@originator-profile/verify";
 import { twMerge } from "tailwind-merge";
 import placeholderLogoMainUrl from "../../assets/placeholder-logo-main.png";
 import { _ } from "../../utils/get-message";
+import { getAnnotationPolicy } from "../../utils/profile-annotation";
 import Image from "../Image";
 import Spinner from "../Spinner";
 import { useProfileAnnotatorWmp } from "./use-profile-annotator-wmp";
@@ -20,7 +20,7 @@ function CertificateDescription(props: { description?: string }) {
   return <p className="text-sm text-gray-600">{props.description}</p>;
 }
 
-function CertificateRef(props: Pick<CertificationSystem, "ref">) {
+function CertificateRef(props: { ref?: string }) {
   if (!props.ref) return null;
   return (
     <a
@@ -45,24 +45,19 @@ function CertificateDetailContent({
   ops,
 }: Props & Required<Pick<Props, "certificate">>) {
   const paWmp = useProfileAnnotatorWmp(ops ?? [], certificate.doc.issuer);
+  const policy = getAnnotationPolicy(certificate.doc.credentialSubject);
   return (
     <>
       <header className="flex items-center gap-3 mb-4">
         <Image
-          src={
-            certificate.doc.credentialSubject.type === "CertificateProperties"
-              ? certificate.doc.credentialSubject.image?.id
-              : undefined
-          }
+          src={certificate.doc.credentialSubject.image?.id}
           placeholderSrc={placeholderLogoMainUrl}
           alt=""
           width={60}
           height={40}
         />
         <div className="space-y-0.5 ">
-          <h2 className="text-sm text-black">
-            {certificate.doc.credentialSubject.certificationSystem.name}
-          </h2>
+          <h2 className="text-sm text-black">{policy.name}</h2>
           <p className="text-xs text-gray-600">
             {_(
               "CertificateDetail_IssuedBy",
@@ -74,14 +69,8 @@ function CertificateDetailContent({
       <CertificateDescription
         description={certificate.doc.credentialSubject.description}
       />
-      <CertificateDescription
-        description={
-          certificate.doc.credentialSubject.certificationSystem.description
-        }
-      />
-      <CertificateRef
-        ref={certificate.doc.credentialSubject.certificationSystem.ref}
-      />
+      <CertificateDescription description={policy.description} />
+      <CertificateRef ref={policy.ref} />
     </>
   );
 }

--- a/packages/ui/src/components/profileAnnotation/CertificateSummary.tsx
+++ b/packages/ui/src/components/profileAnnotation/CertificateSummary.tsx
@@ -3,6 +3,7 @@ import { Certificate, VerifiedOps } from "@originator-profile/verify";
 import { twMerge } from "tailwind-merge";
 import placeholderLogoMainUrl from "../../assets/placeholder-logo-main.png";
 import { _ } from "../../utils/get-message";
+import { getAnnotationPolicy } from "../../utils/profile-annotation";
 import Image from "../Image";
 import { useProfileAnnotatorWmp } from "./use-profile-annotator-wmp";
 
@@ -30,11 +31,7 @@ export function CertificateSummary({
       onClick={handleClick}
     >
       <Image
-        src={
-          certificate.doc.credentialSubject.type === "CertificateProperties"
-            ? certificate.doc.credentialSubject.image?.id
-            : undefined
-        }
+        src={certificate.doc.credentialSubject.image?.id}
         placeholderSrc={placeholderLogoMainUrl}
         alt=""
         width={60}
@@ -42,7 +39,7 @@ export function CertificateSummary({
       />
       <span className="flex flex-col gap-2 items-start">
         <span className="text-sm">
-          {certificate.doc.credentialSubject.certificationSystem.name}
+          {getAnnotationPolicy(certificate.doc.credentialSubject).name}
         </span>
         <span className="text-xs text-gray-600">
           {_(

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { _, getMessage } from "./get-message";
+export { getAnnotationPolicy } from "./profile-annotation";
 export { default as sortCertificates } from "./sort-certificates";
 export { default as useSanitizedHtml } from "./use-sanitized-html";

--- a/packages/ui/src/utils/profile-annotation.ts
+++ b/packages/ui/src/utils/profile-annotation.ts
@@ -1,0 +1,25 @@
+import { Certificate } from "@originator-profile/verify";
+
+type CredentialSubject = Certificate["credentialSubject"];
+
+type AnnotationPolicy = {
+  id: string;
+  name: string;
+  description?: string;
+  ref?: string;
+};
+
+/**
+ * 新形式 PA の `credentialSubject.annotation` と旧 Certificate 形式の
+ * `credentialSubject.certificationSystem` は同一形状なので、存在するほうを返す。
+ */
+export function getAnnotationPolicy(
+  credentialSubject: CredentialSubject,
+): AnnotationPolicy {
+  const subject = credentialSubject as CredentialSubject & {
+    annotation?: AnnotationPolicy;
+    certificationSystem?: AnnotationPolicy;
+  };
+  return (subject.annotation ??
+    subject.certificationSystem) as AnnotationPolicy;
+}

--- a/packages/ui/src/utils/sort-certificates.test.ts
+++ b/packages/ui/src/utils/sort-certificates.test.ts
@@ -1,6 +1,7 @@
 import { VerifiedVc } from "@originator-profile/securing-mechanism";
 import { Certificate } from "@originator-profile/verify";
 import { describe, expect, test } from "vitest";
+import { getAnnotationPolicy } from "./profile-annotation";
 import sortCertificates from "./sort-certificates";
 
 const makeCertificate = (id: string): VerifiedVc<Certificate> => ({
@@ -38,6 +39,40 @@ const makeCertificate = (id: string): VerifiedVc<Certificate> => ({
   },
 });
 
+const makeProfileAnnotation = (id: string): VerifiedVc<Certificate> => ({
+  doc: {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://originator-profile.org/ns/credentials/v1",
+      "https://originator-profile.org/ns/cip/v1",
+      {
+        "@language": "ja",
+      },
+    ],
+    type: ["VerifiableCredential", "ProfileAnnotation"],
+    issuer: "dns:localhost",
+    credentialSubject: {
+      id: "dns:localhost",
+      type: "AdvertisingQualityCertificate",
+      annotation: {
+        id: id,
+        type: "ProfileAnnotationPolicy",
+        name: "Example Profile Annotation Policy",
+        description: "Example Profile Annotation Policy Description",
+      },
+    },
+  },
+  source: "test",
+  validated: false,
+  verificationKey: {
+    crv: "P-256",
+    kid: "jJYs5_ILgUc8180L-pBPxBpgA3QC7eZu9wKOkh9mYPU",
+    kty: "EC",
+    x: "ypAlUjo5O5soUNHk3mlRyfw6ujxqjfD_HMQt7XH-rSg",
+    y: "1cmv9lmZvL0XAERNxvrT2kZkC4Uwu5i1Or1O-4ixJuE",
+  },
+});
+
 describe("sortCertificates", () => {
   test("既知のIDを優先度順に並び替える", () => {
     const input = [
@@ -47,7 +82,7 @@ describe("sortCertificates", () => {
     ];
     const result = sortCertificates(input);
     expect(
-      result.map((c) => c.doc.credentialSubject.certificationSystem.id),
+      result.map((c) => getAnnotationPolicy(c.doc.credentialSubject).id),
     ).toEqual([
       "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
       "urn:uuid:203a2553-f1a8-40ba-9df0-4e508aa8511d",
@@ -63,7 +98,7 @@ describe("sortCertificates", () => {
     ];
     const result = sortCertificates(input);
     expect(
-      result.map((c) => c.doc.credentialSubject.certificationSystem.id),
+      result.map((c) => getAnnotationPolicy(c.doc.credentialSubject).id),
     ).toEqual([
       "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92",
       "urn:uuid:85c92abe-4518-42bb-855d-dffeabfe4a38",
@@ -74,5 +109,37 @@ describe("sortCertificates", () => {
   test("空配列を処理できる", () => {
     const result = sortCertificates([]);
     expect(result).toEqual([]);
+  });
+
+  test("annotation を持つ新形式 PA も並び替えできる", () => {
+    const input = [
+      makeProfileAnnotation("urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92"),
+      makeProfileAnnotation("urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643"),
+      makeProfileAnnotation("urn:uuid:203a2553-f1a8-40ba-9df0-4e508aa8511d"),
+    ];
+    const result = sortCertificates(input);
+    expect(
+      result.map((c) => getAnnotationPolicy(c.doc.credentialSubject).id),
+    ).toEqual([
+      "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
+      "urn:uuid:203a2553-f1a8-40ba-9df0-4e508aa8511d",
+      "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92",
+    ]);
+  });
+
+  test("旧 certificationSystem と新 annotation が混在しても並び替えできる", () => {
+    const input = [
+      makeCertificate("urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92"),
+      makeProfileAnnotation("urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643"),
+      makeCertificate("urn:uuid:2dbf9afe-af9c-4c6a-b6df-70a9565fec5e"),
+    ];
+    const result = sortCertificates(input);
+    expect(
+      result.map((c) => getAnnotationPolicy(c.doc.credentialSubject).id),
+    ).toEqual([
+      "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643",
+      "urn:uuid:2dbf9afe-af9c-4c6a-b6df-70a9565fec5e",
+      "urn:uuid:8029ece0-b327-4a7e-b586-3e442cb82d92",
+    ]);
   });
 });

--- a/packages/ui/src/utils/sort-certificates.ts
+++ b/packages/ui/src/utils/sort-certificates.ts
@@ -29,12 +29,8 @@ const getPriority = (id: string): number => {
  */
 export default function sortCertificates(certificates: Certificate[]) {
   return [...certificates].sort((a, b) => {
-    const priorityA = getPriority(
-      getAnnotationPolicy(a.credentialSubject).id,
-    );
-    const priorityB = getPriority(
-      getAnnotationPolicy(b.credentialSubject).id,
-    );
+    const priorityA = getPriority(getAnnotationPolicy(a.credentialSubject).id);
+    const priorityB = getPriority(getAnnotationPolicy(b.credentialSubject).id);
     return priorityA - priorityB;
   });
 }

--- a/packages/ui/src/utils/sort-certificates.ts
+++ b/packages/ui/src/utils/sort-certificates.ts
@@ -1,5 +1,6 @@
 import { VerifiedVc } from "@originator-profile/securing-mechanism";
 import { Certificate } from "@originator-profile/verify";
+import { getAnnotationPolicy } from "./profile-annotation";
 
 const certificationSystemIdPriorityMap: Record<string, number> = {
   "urn:uuid:def09cbd-6e8e-4c73-856d-5e00dffde643": 1, // Fictitious Organization Existence Verification Agency Existence Certificate
@@ -20,7 +21,7 @@ const getPriority = (id: string): number => {
 };
 
 /**
- * PA を certificationSystem.id の優先度順に並び替えます。
+ * PA を annotation.id (旧 certificationSystem.id) の優先度順に並び替えます。
  *
  * @param certificates - 並び替える PA の配列
  * @returns  優先度順にソートされた新しい PA の配列
@@ -32,10 +33,10 @@ export default function sortCertificates(
 ) {
   return [...certificates].sort((a, b) => {
     const priorityA = getPriority(
-      a.doc.credentialSubject.certificationSystem.id,
+      getAnnotationPolicy(a.doc.credentialSubject).id,
     );
     const priorityB = getPriority(
-      b.doc.credentialSubject.certificationSystem.id,
+      getAnnotationPolicy(b.doc.credentialSubject).id,
     );
     return priorityA - priorityB;
   });

--- a/packages/verify/src/originator-profile-set/types.ts
+++ b/packages/verify/src/originator-profile-set/types.ts
@@ -2,6 +2,8 @@ import {
   Certificate as BasicCertificate,
   CoreProfile,
   JapaneseExistenceCertificate,
+  JapaneseExistencePA,
+  ProfileAnnotation,
   WebMediaProfile,
 } from "@originator-profile/model";
 import {
@@ -18,7 +20,11 @@ import {
   OpVerifyFailed,
 } from "./errors";
 
-export type Certificate = BasicCertificate | JapaneseExistenceCertificate;
+export type Certificate =
+  | BasicCertificate
+  | JapaneseExistenceCertificate
+  | ProfileAnnotation
+  | JapaneseExistencePA;
 
 /** Originator Profile 復号失敗 */
 export type OpDecodingFailure = {

--- a/packages/verify/src/originator-profile-set/verify-ops.ts
+++ b/packages/verify/src/originator-profile-set/verify-ops.ts
@@ -3,8 +3,10 @@ import {
   Certificate as CertificateSchema,
   CoreProfile,
   JapaneseExistenceCertificate,
+  JapaneseExistencePA,
   OpVc,
   OriginatorProfileSet,
+  ProfileAnnotation,
   WebMediaProfile,
 } from "@originator-profile/model";
 import {
@@ -81,7 +83,14 @@ async function verifyAnnotations(
       const verify = OpVerifier<Certificate>(
         paIssuerKeys,
         annotation,
-        validator?.(z.union([CertificateSchema, JapaneseExistenceCertificate])),
+        validator?.(
+          z.union([
+            JapaneseExistencePA,
+            ProfileAnnotation,
+            JapaneseExistenceCertificate,
+            CertificateSchema,
+          ]),
+        ),
       );
 
       const result = await verify(annotation.source);

--- a/packages/verify/src/verify-vc/certificate.test.ts
+++ b/packages/verify/src/verify-vc/certificate.test.ts
@@ -45,7 +45,7 @@ const existenceCertificate = {
   },
 } as const satisfies JapaneseExistenceCertificate;
 
-const jicdaqCertificate = {
+const adQualityCertificate = {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
     "https://originator-profile.org/ns/credentials/v1",
@@ -58,19 +58,19 @@ const jicdaqCertificate = {
     id: "dns:pa-holder.example.jp",
     type: "CertificateProperties",
     description:
-      "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。第三者機関（日本ABC協会）による検証を経て、本認証を取得しました。",
+      "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。",
     image: {
       id: "https://example.com/certification-mark.svg",
       digestSRI: "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
     },
-    certifier: "一般社団法人 デジタル広告品質認証機構",
-    verifier: "日本ABC協会",
+    certifier: "架空広告認証センター",
+    verifier: "架空広告監査機構",
     certificationSystem: {
       id: "urn:uuid:2a12a385-fd1c-48e6-acd8-176c0c5e95ea",
       type: "CertificationSystem",
-      name: "JICDAQ ブランドセーフティ第三者検証",
+      name: "架空広告認証センター ブランドセーフティ認証",
       description: "blah blah blah",
-      ref: "https://www.jicdaq.or.jp/",
+      ref: "https://adcert.exp.originator-profile.org/",
     },
   },
   validFrom: "2022-03-31T15:00:00Z",
@@ -121,19 +121,19 @@ describe("Certificate", () => {
     expect(result.doc).toStrictEqual(existenceCertificate);
   });
 
-  test("JICDAQ 証明書の検証に成功", async () => {
+  test("広告品質認証証明書の検証に成功", async () => {
     const { publicKey, privateKey } = await generateKey();
     const keys = LocalKeys({ keys: [publicKey] });
     const validator = VcValidator<VerifiedJwtVc<Certificate>>(Certificate);
     const verifier = JwtVcVerifier(keys, VERIFIER_ID, validator);
-    const jwt = await signJwtVc(jicdaqCertificate, privateKey, {
+    const jwt = await signJwtVc(adQualityCertificate, privateKey, {
       issuedAt,
       expiredAt,
     });
     const result = await verifier(jwt);
     expect(result).not.toBeInstanceOf(Error);
     // @ts-expect-error assert
-    expect(result.doc).toStrictEqual(jicdaqCertificate);
+    expect(result.doc).toStrictEqual(adQualityCertificate);
   });
 
   test("日本新聞協会所属証明書の検証に成功", async () => {

--- a/packages/verify/src/verify-vc/profile-annotation.test.ts
+++ b/packages/verify/src/verify-vc/profile-annotation.test.ts
@@ -1,0 +1,112 @@
+import { generateKey, LocalKeys } from "@originator-profile/cryptography";
+import {
+  JapaneseExistencePA,
+  ProfileAnnotation,
+} from "@originator-profile/model";
+import {
+  JwtVcVerifier,
+  signJwtVc,
+  VcValidator,
+  VerifiedJwtVc,
+} from "@originator-profile/securing-mechanism";
+import { addYears } from "date-fns";
+import { describe, expect, test } from "vitest";
+
+const VERIFIER_ID = "dns:pa-issuer.example.org";
+const issuedAt = new Date();
+const expiredAt = addYears(new Date(), 10);
+
+const existencePA = {
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    { "@language": "ja" },
+  ],
+  type: ["VerifiableCredential", "ProfileAnnotation"],
+  issuer: "dns:pa-issuer.example.org",
+  credentialSubject: {
+    id: "dns:pa-holder.example.jp",
+    type: "JP-OrganizationExistenceCertificate",
+    name: "○○新聞社 (※開発用サンプル)",
+    corporateName: "○○新聞社 (※開発用サンプル)",
+    corporateNumber: "0000000000000",
+    postalCode: "000-0000",
+    addressCountry: "JP",
+    addressRegion: "東京都",
+    addressLocality: "千代田区",
+    streetAddress: "○○○",
+    annotation: {
+      id: "urn:uuid:5374a35f-57ce-43fd-84c3-2c9b0163e3df",
+      type: "ProfileAnnotationPolicy",
+      name: "法人番号システムWeb-API",
+      description: "blah blah blah",
+      ref: "https://www.houjin-bangou.nta.go.jp/",
+    },
+  },
+} as const satisfies JapaneseExistencePA;
+
+const adQualityPA = {
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://originator-profile.org/ns/credentials/v1",
+    "https://originator-profile.org/ns/cip/v1",
+    { "@language": "ja" },
+  ],
+  type: ["VerifiableCredential", "ProfileAnnotation"],
+  issuer: "dns:pa-issuer.example.org",
+  credentialSubject: {
+    id: "dns:pa-holder.example.jp",
+    type: "AdvertisingQualityCertificate",
+    description:
+      "この事業者は、広告主のブランド価値を毀損するような違法、不当なサイト、コンテンツ、アプリケーションへの広告掲載を防ぐ対策を実施しています。",
+    image: {
+      id: "https://example.com/certification-mark.svg",
+      digestSRI: "sha256-uU0nuZNNPgilLlLX2n2r+sSE7+N6U4DukIj3rOLvzek=",
+    },
+    verifier: "架空広告監査機構",
+    annotation: {
+      id: "urn:uuid:2a12a385-fd1c-48e6-acd8-176c0c5e95ea",
+      type: "ProfileAnnotationPolicy",
+      name: "架空広告認証センター ブランドセーフティ認証",
+      description: "blah blah blah",
+      ref: "https://adcert.exp.originator-profile.org/",
+    },
+  },
+  validFrom: "2022-03-31T15:00:00Z",
+  validUntil: "2024-03-31T14:59:59Z",
+} as const satisfies ProfileAnnotation;
+
+describe("ProfileAnnotation", () => {
+  test("組織実在 PA の検証に成功", async () => {
+    const { publicKey, privateKey } = await generateKey();
+    const keys = LocalKeys({ keys: [publicKey] });
+    const validator =
+      VcValidator<VerifiedJwtVc<JapaneseExistencePA>>(JapaneseExistencePA);
+    const verifier = JwtVcVerifier(keys, VERIFIER_ID, validator);
+    const jwt = await signJwtVc(existencePA, privateKey, {
+      issuedAt,
+      expiredAt,
+    });
+    const result = await verifier(jwt);
+    expect(result).not.toBeInstanceOf(Error);
+    // @ts-expect-error assert
+    expect(result.doc).toStrictEqual(existencePA);
+  });
+
+  test("広告品質認証 PA の検証に成功", async () => {
+    const { publicKey, privateKey } = await generateKey();
+    const keys = LocalKeys({ keys: [publicKey] });
+    const validator =
+      VcValidator<VerifiedJwtVc<ProfileAnnotation>>(ProfileAnnotation);
+    const verifier = JwtVcVerifier(keys, VERIFIER_ID, validator);
+    const jwt = await signJwtVc(adQualityPA, privateKey, {
+      issuedAt,
+      expiredAt,
+    });
+    const result = await verifier(jwt);
+    expect(result).not.toBeInstanceOf(Error);
+    // @ts-expect-error assert
+    expect(result.doc).toStrictEqual(adQualityPA);
+  });
+});


### PR DESCRIPTION
## Summary
- 新 Profile Annotation モデル (`ProfileAnnotation`, `ProfileAnnotationPolicy`, `ProfileAnnotationProperties`, `JapaneseExistencePA`) を `@originator-profile/model` に追加
- 後方互換性のため旧 `Certificate` / `CertificationSystem` / `JapaneseExistenceCertificate` 系は維持しつつ `@deprecated` 化
- `verify-ops` のバリデータを新旧両形式を受け入れる union に拡張
- `sort-certificates` と `CertificateDetail` / `CertificateSummary` を新 PA 形式 (`credentialSubject.annotation`) と旧形式 (`credentialSubject.certificationSystem`) の両方に対応
- 新 PA モデルの sign / verify テストを追加

Refs:
- https://docs.originator-profile.org/ja/opb/pa-model/pa-policy/
- https://docs.originator-profile.org/ja/opb/pa/
- https://docs.originator-profile.org/ja/opb/pa-model/advertising-certification/
- https://docs.originator-profile.org/ja/opb/pa-model/existence/
- https://docs.originator-profile.org/ja/opb/pa-model/local-government-certification/
- https://docs.originator-profile.org/ja/opb/pa-model/news-media-registration/

Closes #286

## Test plan
- [x] \`pnpm -r test\` — 全 workspace 緑（model 67 / sign 42 / verify 121 / ui 5 / inspector 41 等）
- [x] \`pnpm -r type-check\` — エラーなし
- [x] \`pnpm -r lint\` — エラーなし
- [x] \`pnpm -r build\` — 成功
- [ ] 既存の旧 Certificate 形式の VC が引き続き verify される (verify-vc/certificate.test.ts, sort-certificates.test.ts でカバー)
- [ ] 新 ProfileAnnotation 形式の VC が verify される (verify-vc/profile-annotation.test.ts でカバー)

🤖 Generated with [Claude Code](https://claude.com/claude-code)