### PR TITLE
fix(inspector): shorten English extension description to fit 132-char limit (149 -> 127)

### DIFF
--- a/apps/inspector/public/_locales/en/messages.json
+++ b/apps/inspector/public/_locales/en/messages.json
@@ -3,7 +3,7 @@
     "message": "OP Inspector"
   },
   "extensionDescription": {
-    "message": "OP Inspector is a tool for visualizing and verifying content digitized with OP technology, including who created it and what kind of entity they are."
+    "message": "A tool to visualize and verify content digitized with OP technology, including who created it and what kind of entity they are."
   },
   "CaFilter_All": {
     "message": "All"


### PR DESCRIPTION
## 概要

`0667fcdbc8be866340cf9c271aad7c9e76805d7c`（`v0.5` ブランチ）を main に cherry-pick します。

Inspector 拡張機能の英語版 `extensionDescription` が 149 文字あり、Chrome の拡張機能説明の 132 文字制限を超えていたため、127 文字に短縮します。

## 変更内容

- `apps/inspector/public/_locales/en/messages.json` の `extensionDescription` を短縮（149 → 127 文字）

```diff
- "message": "OP Inspector is a tool for visualizing and verifying content digitized with OP technology, including who created it and what kind of entity they are."
+ "message": "A tool to visualize and verify content digitized with OP technology, including who created it and what kind of entity they are."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)