### PR TITLE
fetchVerifiedCredentials 関数と verifyTabCredentials 関数のリファクタリング

### DIFF
--- a/apps/inspector/src/components/credentials/use-credentials.ts
+++ b/apps/inspector/src/components/credentials/use-credentials.ts
@@ -2,7 +2,7 @@ import { VerifiedOps, VerifiedSp } from "@originator-profile/verify";
 import { useParams } from "react-router";
 import useSWRImmutable from "swr/immutable";
 import { useSiteProfile } from "../siteProfile";
-import { fetchVerificationResult } from "./messaging";
+import { fetchTabCredentials, fetchVerificationResult } from "./messaging";
 import type { FramesVerifiedCas, SupportedVerifiedCas } from "./types";
 import { verifyAllCredentials } from "./verify-credentials";
 
@@ -26,17 +26,18 @@ async function fetchVerifiedCredentials([, tabId, sp]: [
   tabId: number,
   sp?: VerifiedSp,
 ]): Promise<FetchVerifiedCredentialsResult> {
-  const result = await verifyAllCredentials(tabId, sp);
+  const { frames, ...page } = await fetchTabCredentials(tabId);
+  const result = await verifyAllCredentials(tabId, page, frames, sp);
 
-  if (!result.verify) {
-    throw result.error;
+  if (result instanceof Error) {
+    throw result;
   }
 
   return {
     ops: result.ops,
     cas: result.cas,
-    origin: result.page.origin,
-    url: result.page.url,
+    origin: page.origin,
+    url: page.url,
     framesCas: result.casResults.map(({ result: cas, frame }) => ({
       cas: cas as SupportedVerifiedCas,
       url: frame.url,

--- a/apps/inspector/src/components/credentials/use-credentials.ts
+++ b/apps/inspector/src/components/credentials/use-credentials.ts
@@ -1,17 +1,10 @@
-import {
-  CasVerifyFailed,
-  OpsInvalid,
-  OpsVerifyFailed,
-  VerifiedOps,
-  VerifiedSp,
-} from "@originator-profile/verify";
+import { VerifiedOps, VerifiedSp } from "@originator-profile/verify";
 import { useParams } from "react-router";
 import useSWRImmutable from "swr/immutable";
 import { useSiteProfile } from "../siteProfile";
-import { deduplicateCas } from "./deduplicate-cas";
-import { fetchTabCredentials, fetchVerificationResult } from "./messaging";
+import { fetchVerificationResult } from "./messaging";
 import type { FramesVerifiedCas, SupportedVerifiedCas } from "./types";
-import { verifyFramesCas, verifyOps } from "./verify-credentials";
+import { verifyAllCredentials } from "./verify-credentials";
 
 const CREDENTIALS_KEY = "credentials";
 
@@ -33,38 +26,19 @@ async function fetchVerifiedCredentials([, tabId, sp]: [
   tabId: number,
   sp?: VerifiedSp,
 ]): Promise<FetchVerifiedCredentialsResult> {
-  const { frames, ...page } = await fetchTabCredentials(tabId);
+  const result = await verifyAllCredentials(tabId, sp);
 
-  // OPS 検証
-  const verifiedOps = await verifyOps(page, frames, sp);
-  if (
-    verifiedOps instanceof OpsInvalid ||
-    verifiedOps instanceof OpsVerifyFailed
-  ) {
-    throw verifiedOps;
-  }
-
-  // CAS 検証
-  const casResults = await verifyFramesCas(
-    tabId,
-    [page, ...frames],
-    verifiedOps,
-  );
-  for (const { result } of casResults) {
-    if (result instanceof CasVerifyFailed) {
-      throw result;
-    }
+  if (!result.verify) {
+    throw result.error;
   }
 
   return {
-    ops: verifiedOps,
-    cas: deduplicateCas(
-      casResults.flatMap(({ result }) => result as SupportedVerifiedCas),
-    ),
-    origin: page.origin,
-    url: page.url,
-    framesCas: casResults.map(({ result, frame }) => ({
-      cas: result as SupportedVerifiedCas,
+    ops: result.ops,
+    cas: result.cas,
+    origin: result.page.origin,
+    url: result.page.url,
+    framesCas: result.casResults.map(({ result: cas, frame }) => ({
+      cas: cas as SupportedVerifiedCas,
       url: frame.url,
       origin: frame.origin,
       frameId: frame.frameId,

--- a/apps/inspector/src/components/credentials/verify-credentials.ts
+++ b/apps/inspector/src/components/credentials/verify-credentials.ts
@@ -9,7 +9,8 @@ import {
   verifyCas,
 } from "@originator-profile/verify";
 import { getRegistryKeys } from "../../utils/get-registry-keys";
-import { FrameIntegrityVerifier } from "./messaging";
+import { deduplicateCas } from "./deduplicate-cas";
+import { fetchTabCredentials, FrameIntegrityVerifier } from "./messaging";
 import type { SupportedCa, SupportedVerifiedCas } from "./types";
 
 /**
@@ -72,4 +73,57 @@ export async function verifyFramesCas<F extends FrameCasInput>(
       ).then((result) => ({ result, frame })),
     ),
   );
+}
+
+/**
+ * タブ内のクレデンシャルを検証する共通関数
+ * @param tabId タブID
+ * @param siteProfile Site Profile
+ * @returns
+ *    - 成功時: { verify: true, ops, cas, casResults, page, frames }
+ *    - 失敗時: { verify: false, error }
+ *
+ * verify は判定フラグ
+ */
+export async function verifyAllCredentials(
+  tabId: number,
+  siteProfile?: VerifiedSp | null,
+) {
+  const { frames, ...page } = await fetchTabCredentials(tabId);
+
+  // OPS 検証
+  const verifiedOps = await verifyOps(page, frames, siteProfile);
+  if (
+    verifiedOps instanceof OpsInvalid ||
+    verifiedOps instanceof OpsVerifyFailed
+  ) {
+    return { verify: false as const, error: verifiedOps };
+  }
+
+  // CAS 検証
+  const casResults = await verifyFramesCas(
+    tabId,
+    [page, ...frames],
+    verifiedOps,
+  );
+  const failedCas = casResults.find(
+    ({ result }) => result instanceof CasVerifyFailed,
+  );
+  if (failedCas) {
+    return {
+      verify: false as const,
+      error: failedCas.result as CasVerifyFailed,
+    };
+  }
+
+  return {
+    verify: true as const,
+    ops: verifiedOps,
+    cas: deduplicateCas(
+      casResults.flatMap(({ result }) => result as SupportedVerifiedCas),
+    ),
+    casResults,
+    page,
+    frames,
+  };
 }

--- a/apps/inspector/src/components/credentials/verify-credentials.ts
+++ b/apps/inspector/src/components/credentials/verify-credentials.ts
@@ -10,8 +10,13 @@ import {
 } from "@originator-profile/verify";
 import { getRegistryKeys } from "../../utils/get-registry-keys";
 import { deduplicateCas } from "./deduplicate-cas";
-import { fetchTabCredentials, FrameIntegrityVerifier } from "./messaging";
-import type { SupportedCa, SupportedVerifiedCas } from "./types";
+import { FrameIntegrityVerifier } from "./messaging";
+import type {
+  FrameCredentials,
+  SupportedCa,
+  SupportedVerifiedCas,
+  TabCredentials,
+} from "./types";
 
 /**
  * OPSを検証する。
@@ -78,26 +83,26 @@ export async function verifyFramesCas<F extends FrameCasInput>(
 /**
  * タブ内のクレデンシャルを検証する共通関数
  * @param tabId タブID
+ * @param page ページ
+ * @param frames フレームのリスト
  * @param siteProfile Site Profile
  * @returns
- *    - 成功時: { verify: true, ops, cas, casResults, page, frames }
- *    - 失敗時: { verify: false, error }
- *
- * verify は判定フラグ
+ *    - 成功時: { ops, cas, casResults }
+ *    - 失敗時: 検証失敗した結果
  */
 export async function verifyAllCredentials(
   tabId: number,
+  page: Omit<TabCredentials, "frames">,
+  frames: FrameCredentials[],
   siteProfile?: VerifiedSp | null,
 ) {
-  const { frames, ...page } = await fetchTabCredentials(tabId);
-
   // OPS 検証
   const verifiedOps = await verifyOps(page, frames, siteProfile);
   if (
     verifiedOps instanceof OpsInvalid ||
     verifiedOps instanceof OpsVerifyFailed
   ) {
-    return { verify: false as const, error: verifiedOps };
+    return verifiedOps;
   }
 
   // CAS 検証
@@ -110,20 +115,14 @@ export async function verifyAllCredentials(
     ({ result }) => result instanceof CasVerifyFailed,
   );
   if (failedCas) {
-    return {
-      verify: false as const,
-      error: failedCas.result as CasVerifyFailed,
-    };
+    return failedCas.result as CasVerifyFailed;
   }
 
   return {
-    verify: true as const,
     ops: verifiedOps,
     cas: deduplicateCas(
       casResults.flatMap(({ result }) => result as SupportedVerifiedCas),
     ),
     casResults,
-    page,
-    frames,
   };
 }

--- a/apps/inspector/src/components/tabBadge/verify.ts
+++ b/apps/inspector/src/components/tabBadge/verify.ts
@@ -1,6 +1,7 @@
 import { deserializeIfError } from "@originator-profile/core";
 import { SpVerifier, VerifiedSp } from "@originator-profile/verify";
 import { getRegistryKeys } from "../../utils/get-registry-keys";
+import { fetchTabCredentials } from "../credentials";
 import type { SupportedVerifiedCas } from "../credentials/types";
 import { verifyAllCredentials } from "../credentials/verify-credentials";
 import { siteProfileMessenger } from "../siteProfile/events";
@@ -64,10 +65,13 @@ export async function verifyTabCredentials(tabId: number): Promise<{
   count: number;
 } | null> {
   try {
-    const siteProfile = await fetchVerifiedSiteProfile(tabId);
-    const result = await verifyAllCredentials(tabId, siteProfile);
+    const [siteProfile, { frames, ...page }] = await Promise.all([
+      fetchVerifiedSiteProfile(tabId),
+      fetchTabCredentials(tabId),
+    ]);
+    const result = await verifyAllCredentials(tabId, page, frames, siteProfile);
 
-    if (!result.verify) return null;
+    if (result instanceof Error) return null;
 
     return {
       verifiedCas: result.cas,

--- a/apps/inspector/src/components/tabBadge/verify.ts
+++ b/apps/inspector/src/components/tabBadge/verify.ts
@@ -1,16 +1,8 @@
 import { deserializeIfError } from "@originator-profile/core";
-import {
-  CasVerifyFailed,
-  OpsInvalid,
-  OpsVerifyFailed,
-  SpVerifier,
-  VerifiedSp,
-} from "@originator-profile/verify";
+import { SpVerifier, VerifiedSp } from "@originator-profile/verify";
 import { getRegistryKeys } from "../../utils/get-registry-keys";
-import { deduplicateCas } from "../credentials/deduplicate-cas";
-import { fetchTabCredentials } from "../credentials/messaging";
 import type { SupportedVerifiedCas } from "../credentials/types";
-import { verifyFramesCas, verifyOps } from "../credentials/verify-credentials";
+import { verifyAllCredentials } from "../credentials/verify-credentials";
 import { siteProfileMessenger } from "../siteProfile/events";
 
 /**
@@ -72,38 +64,14 @@ export async function verifyTabCredentials(tabId: number): Promise<{
   count: number;
 } | null> {
   try {
-    // Site ProfileとCredentialsを並行取得
-    const [siteProfile, { frames, ...page }] = await Promise.all([
-      fetchVerifiedSiteProfile(tabId),
-      fetchTabCredentials(tabId),
-    ]);
+    const siteProfile = await fetchVerifiedSiteProfile(tabId);
+    const result = await verifyAllCredentials(tabId, siteProfile);
 
-    // OPS 検証
-    const verifiedOps = await verifyOps(page, frames, siteProfile);
-    if (
-      verifiedOps instanceof OpsInvalid ||
-      verifiedOps instanceof OpsVerifyFailed
-    ) {
-      return null;
-    }
-
-    // CAS 検証
-    const casResults = await verifyFramesCas(
-      tabId,
-      [page, ...frames],
-      verifiedOps,
-    );
-    if (casResults.some(({ result }) => result instanceof CasVerifyFailed)) {
-      return null;
-    }
-
-    const allVerifiedCas = deduplicateCas(
-      casResults.flatMap(({ result }) => result as SupportedVerifiedCas),
-    );
+    if (!result.verify) return null;
 
     return {
-      verifiedCas: allVerifiedCas,
-      count: allVerifiedCas.length,
+      verifiedCas: result.cas,
+      count: result.cas.length,
     };
   } catch (error) {
     console.error(


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- fetchVerifiedCredentials 関数と verifyTabCredentials 関数の検証フロー（クレデンシャル取得→OPS 検証→CAS 検証→重複削除）部分について、verify-credentials.ts に共通のコア関数を追加し、両方がそれを利用する形にリファクタリングしました。

close #328

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- テストが通ることをご確認ください。
- `pnpm dev` 後、http://localhost:8080/examples/cas-1.html 等にて拡張機能を使用し、検証が通ることをご確認ください。