### PR TITLE
feat(inspector): 詳細情報画面に検証中の警告ログを表示

### DIFF
--- a/apps/inspector/e2e/site-profile.test.ts
+++ b/apps/inspector/e2e/site-profile.test.ts
@@ -98,3 +98,24 @@ test("Site Profile を取得検証できるが、有効期限が近く、詳細�
       .first(),
   ).toBeVisible();
 });
+
+test("詳細情報画面に検証中の警告ログが表示される", async ({
+  context,
+  page,
+  validSiteProfile,
+  credentialsMissingPage,
+}) => {
+  await validSiteProfile(
+    { privateKey, publicKey },
+    credentialsMissingPage.issuer,
+  );
+  await page.goto(credentialsMissingPage.endpoint);
+  const ext = await sidepanel(context);
+  await expect(ext?.getByTestId("site-profile")).toBeVisible();
+
+  await gotoDetailPage(ext);
+  // フィクスチャの WSP image には digestSRI が無いため警告が表示される
+  await expect(ext.getByTestId("verification-warnings")).toContainText(
+    "digestSRI is missing",
+  );
+});

--- a/apps/inspector/public/_locales/en/messages.json
+++ b/apps/inspector/public/_locales/en/messages.json
@@ -359,6 +359,9 @@
   "DetailInfo_SourceAdOrganization": {
     "message": "Source Ad Organization"
   },
+  "DetailInfo_Warnings": {
+    "message": "Warnings"
+  },
   "Link_OriginatorProfile": {
     "message": "Learn more about Originator Profile (external site)"
   },

--- a/apps/inspector/public/_locales/ja/messages.json
+++ b/apps/inspector/public/_locales/ja/messages.json
@@ -359,6 +359,9 @@
   "DetailInfo_SourceAdOrganization": {
     "message": "リンク元広告の組織"
   },
+  "DetailInfo_Warnings": {
+    "message": "警告"
+  },
   "Link_OriginatorProfile": {
     "message": "Originator Profile についてより詳しく（外部サイト）"
   },

--- a/apps/inspector/src/components/credentials/use-credentials.ts
+++ b/apps/inspector/src/components/credentials/use-credentials.ts
@@ -14,6 +14,7 @@ type FetchVerifiedCredentialsResult = {
   origin: string;
   url: string;
   framesCas: FramesVerifiedCas;
+  warnings: string[];
 };
 
 /**
@@ -45,6 +46,7 @@ async function fetchVerifiedCredentials([, tabId, sp]: [
       frameId: frame.frameId,
       parentFrameId: frame.parentFrameId,
     })),
+    warnings: result.warnings,
   };
 }
 
@@ -57,6 +59,7 @@ type UseCredentialsResult =
       ops: undefined;
       origin: undefined;
       tabId: number;
+      warnings: undefined;
     }
   | {
       cas: undefined;
@@ -66,6 +69,7 @@ type UseCredentialsResult =
       ops: undefined;
       origin: undefined;
       tabId: number;
+      warnings: undefined;
     }
   | {
       cas: SupportedVerifiedCas;
@@ -75,6 +79,7 @@ type UseCredentialsResult =
       ops: VerifiedOps;
       origin: string;
       tabId: number;
+      warnings: string[];
     };
 
 /**
@@ -93,7 +98,7 @@ export function useCredentials() {
     Error,
     [typeof CREDENTIALS_KEY, number, VerifiedSp?]
   >([CREDENTIALS_KEY, tabId, siteProfile], fetchVerifiedCredentials);
-  const { ops, cas, origin, framesCas } = credentials ?? {};
+  const { ops, cas, origin, framesCas, warnings } = credentials ?? {};
 
   return {
     cas,
@@ -103,6 +108,7 @@ export function useCredentials() {
     ops,
     origin,
     tabId,
+    warnings,
   } as UseCredentialsResult;
 }
 

--- a/apps/inspector/src/components/credentials/verify-credentials.ts
+++ b/apps/inspector/src/components/credentials/verify-credentials.ts
@@ -39,8 +39,7 @@ export async function verifyOps(
     [...registryOps, ...page.ops, ...frames.flatMap((frame) => frame.ops)],
     verificationKeys,
     cpIssuer,
-    undefined,
-    warn,
+    { warn },
   );
   const verifiedOps = await opsVerifier();
 

--- a/apps/inspector/src/components/credentials/verify-credentials.ts
+++ b/apps/inspector/src/components/credentials/verify-credentials.ts
@@ -7,6 +7,7 @@ import {
   type VerifiedOps,
   type VerifiedSp,
   verifyCas,
+  type WarnHandler,
 } from "@originator-profile/verify";
 import { getRegistryOps } from "../../utils/registry-ops";
 import { deduplicateCas } from "./deduplicate-cas";
@@ -27,6 +28,7 @@ export async function verifyOps(
   page: { ops: Parameters<typeof OpsVerifier>[0] },
   frames: { ops: Parameters<typeof OpsVerifier>[0] }[],
   siteProfile?: VerifiedSp | null,
+  warn?: WarnHandler,
 ): ReturnType<ReturnType<typeof OpsVerifier>> {
   const {
     ops: registryOps,
@@ -37,6 +39,8 @@ export async function verifyOps(
     [...registryOps, ...page.ops, ...frames.flatMap((frame) => frame.ops)],
     verificationKeys,
     cpIssuer,
+    undefined,
+    warn,
   );
   const verifiedOps = await opsVerifier();
 
@@ -87,7 +91,7 @@ export async function verifyFramesCas<F extends FrameCasInput>(
  * @param frames フレームのリスト
  * @param siteProfile Site Profile
  * @returns
- *    - 成功時: { ops, cas, casResults }
+ *    - 成功時: { ops, cas, casResults, warnings }
  *    - 失敗時: 検証失敗した結果
  */
 export async function verifyAllCredentials(
@@ -96,8 +100,15 @@ export async function verifyAllCredentials(
   frames: FrameCredentials[],
   siteProfile?: VerifiedSp | null,
 ) {
+  // 検証中の警告を収集する (コンソールへの出力は維持)
+  const warnings: string[] = [];
+  const warn: WarnHandler = (message) => {
+    console.warn(message);
+    warnings.push(message);
+  };
+
   // OPS 検証
-  const verifiedOps = await verifyOps(page, frames, siteProfile);
+  const verifiedOps = await verifyOps(page, frames, siteProfile, warn);
   if (
     verifiedOps instanceof OpsInvalid ||
     verifiedOps instanceof OpsVerifyFailed
@@ -124,5 +135,6 @@ export async function verifyAllCredentials(
       casResults.flatMap(({ result }) => result as SupportedVerifiedCas),
     ),
     casResults,
+    warnings,
   };
 }

--- a/apps/inspector/src/components/siteProfile/use-site-profile.ts
+++ b/apps/inspector/src/components/siteProfile/use-site-profile.ts
@@ -1,4 +1,8 @@
-import { SpVerifier, VerifiedSp } from "@originator-profile/verify";
+import {
+  SpVerifier,
+  VerifiedSp,
+  type WarnHandler,
+} from "@originator-profile/verify";
 import { useParams } from "react-router";
 import useSWRImmutable from "swr/immutable";
 import { getRegistryOps } from "../../utils/registry-ops";
@@ -6,15 +10,27 @@ import { fetchTabSiteProfile } from "./messaging";
 
 const key = "site-profile";
 
+type FetchVerifiedSiteProfileResult = {
+  siteProfile: VerifiedSp;
+  warnings: string[];
+};
+
 async function fetchVerifiedSiteProfile([, tabId]: [
   _: typeof key,
   tabId: number,
-]): Promise<VerifiedSp> {
+]): Promise<FetchVerifiedSiteProfileResult> {
   const data = await fetchTabSiteProfile(tabId);
   const {
     ops: registryOps,
     keys: [cpIssuer, verificationKeys],
   } = await getRegistryOps();
+
+  // 検証中の警告を収集する (コンソールへの出力は維持)
+  const warnings: string[] = [];
+  const warn: WarnHandler = (message) => {
+    console.warn(message);
+    warnings.push(message);
+  };
 
   const verifySp = SpVerifier(
     {
@@ -24,13 +40,16 @@ async function fetchVerifiedSiteProfile([, tabId]: [
     verificationKeys,
     cpIssuer,
     data.origin,
+    undefined,
+    undefined,
+    warn,
   );
 
   const verifiedSp = await verifySp();
   if (verifiedSp instanceof Error) {
     throw verifiedSp;
   }
-  return verifiedSp;
+  return { siteProfile: verifiedSp, warnings };
 }
 
 /**
@@ -40,7 +59,7 @@ export function useSiteProfile() {
   const params = useParams<{ tabId: string }>();
   const tabId = Number(params.tabId);
   const { data, error, isLoading } = useSWRImmutable<
-    VerifiedSp,
+    FetchVerifiedSiteProfileResult,
     Error,
     [typeof key, number]
   >([key, tabId], fetchVerifiedSiteProfile, {
@@ -50,7 +69,8 @@ export function useSiteProfile() {
   return {
     error,
     isLoading,
-    siteProfile: data,
+    siteProfile: data?.siteProfile,
     tabId,
+    warnings: data?.warnings,
   };
 }

--- a/apps/inspector/src/components/siteProfile/use-site-profile.ts
+++ b/apps/inspector/src/components/siteProfile/use-site-profile.ts
@@ -40,9 +40,7 @@ async function fetchVerifiedSiteProfile([, tabId]: [
     verificationKeys,
     cpIssuer,
     data.origin,
-    undefined,
-    undefined,
-    warn,
+    { warn },
   );
 
   const verifiedSp = await verifySp();

--- a/apps/inspector/src/pages/Base.tsx
+++ b/apps/inspector/src/pages/Base.tsx
@@ -124,10 +124,7 @@ function Base() {
     return <Loading />;
   }
 
-  if (
-    isSpVerifyError(spError) ||
-    isCredentialsVerifyError(credentialsError)
-  ) {
+  if (isSpVerifyError(spError) || isCredentialsVerifyError(credentialsError)) {
     return <Prohibition tabId={tabId} />;
   }
 

--- a/apps/inspector/src/pages/Base.tsx
+++ b/apps/inspector/src/pages/Base.tsx
@@ -72,47 +72,47 @@ function Prohibition({ tabId }: { tabId: number }) {
 
 function isLoading({
   siteProfile,
-  sp_error,
+  spError,
   ops,
   cas,
-  credentials_error,
+  credentialsError,
 }: {
   siteProfile?: VerifiedSp;
-  sp_error?: Error;
+  spError?: Error;
   ops?: VerifiedOps;
   cas?: VerifiedCas;
-  credentials_error?: Error;
+  credentialsError?: Error;
 }) {
-  return (!siteProfile && !sp_error) || (!ops && !cas && !credentials_error);
+  return (!siteProfile && !spError) || (!ops && !cas && !credentialsError);
 }
 
-function isSpVerifyError(sp_error?: Error) {
-  if (!sp_error) {
+function isSpVerifyError(spError?: Error) {
+  if (!spError) {
     return false;
   }
 
   return (
-    "code" in sp_error &&
-    (sp_error.code === SiteProfileVerifyFailed.code ||
-      sp_error.code === SiteProfileInvalid.code)
+    "code" in spError &&
+    (spError.code === SiteProfileVerifyFailed.code ||
+      spError.code === SiteProfileInvalid.code)
   );
 }
 
-function isCredentialsVerifyError(credentials_error?: Error) {
-  if (!credentials_error) {
+function isCredentialsVerifyError(credentialsError?: Error) {
+  if (!credentialsError) {
     return false;
   }
 
   return (
-    "code" in credentials_error &&
-    (credentials_error.code === OpsVerifyFailed.code ||
-      credentials_error.code === CasVerifyFailed.code)
+    "code" in credentialsError &&
+    (credentialsError.code === OpsVerifyFailed.code ||
+      credentialsError.code === CasVerifyFailed.code)
   );
 }
 
 function Base() {
-  const { tabId, siteProfile, error: sp_error } = useSiteProfile();
-  const { ops, cas, framesCas, error: credentials_error } = useCredentials();
+  const { tabId, siteProfile, error: spError } = useSiteProfile();
+  const { ops, cas, framesCas, error: credentialsError } = useCredentials();
   useFrameCasLocationProvider(tabId, framesCas ?? []);
 
   const title = [_("Base_ContentsInformation"), origin]
@@ -120,13 +120,13 @@ function Base() {
     .join(" ― ");
   useTitle(formatBuildModeTitle(import.meta.env.MODE, title));
 
-  if (isLoading({ siteProfile, sp_error, ops, cas, credentials_error })) {
+  if (isLoading({ siteProfile, spError, ops, cas, credentialsError })) {
     return <Loading />;
   }
 
   if (
-    isSpVerifyError(sp_error) ||
-    isCredentialsVerifyError(credentials_error)
+    isSpVerifyError(spError) ||
+    isCredentialsVerifyError(credentialsError)
   ) {
     return <Prohibition tabId={tabId} />;
   }
@@ -136,7 +136,7 @@ function Base() {
     return <Redirect tabId={tabId} ops={ops} framesCas={framesCas} />;
   }
 
-  const errors = [sp_error, credentials_error].filter(
+  const errors = [spError, credentialsError].filter(
     (
       error,
     ): error is

--- a/apps/inspector/src/pages/DetailInfo.tsx
+++ b/apps/inspector/src/pages/DetailInfo.tsx
@@ -6,8 +6,18 @@ import Template from "../templates/DetailInfo";
 type Props = { back: string };
 
 function DetailInfo(props: Props) {
-  const { siteProfile, error: sp_error } = useSiteProfile();
-  const { ops, cas, framesCas, error: credentials_error } = useCredentials();
+  const {
+    siteProfile,
+    error: sp_error,
+    warnings: sp_warnings,
+  } = useSiteProfile();
+  const {
+    ops,
+    cas,
+    framesCas,
+    error: credentials_error,
+    warnings: credentials_warnings,
+  } = useCredentials();
   const [queryParams] = useSearchParams();
   const backPath = {
     pathname: props.back,
@@ -20,6 +30,7 @@ function DetailInfo(props: Props) {
       cas={cas}
       framesCas={framesCas}
       errors={[sp_error, credentials_error].filter((x) => x !== undefined)}
+      warnings={[...(sp_warnings ?? []), ...(credentials_warnings ?? [])]}
       backPath={backPath}
     />
   );

--- a/apps/inspector/src/pages/DetailInfo.tsx
+++ b/apps/inspector/src/pages/DetailInfo.tsx
@@ -8,15 +8,15 @@ type Props = { back: string };
 function DetailInfo(props: Props) {
   const {
     siteProfile,
-    error: sp_error,
-    warnings: sp_warnings,
+    error: spError,
+    warnings: spWarnings,
   } = useSiteProfile();
   const {
     ops,
     cas,
     framesCas,
-    error: credentials_error,
-    warnings: credentials_warnings,
+    error: credentialsError,
+    warnings: credentialsWarnings,
   } = useCredentials();
   const [queryParams] = useSearchParams();
   const backPath = {
@@ -29,8 +29,8 @@ function DetailInfo(props: Props) {
       ops={ops}
       cas={cas}
       framesCas={framesCas}
-      errors={[sp_error, credentials_error].filter((x) => x !== undefined)}
-      warnings={[...(sp_warnings ?? []), ...(credentials_warnings ?? [])]}
+      errors={[spError, credentialsError].filter((x) => x !== undefined)}
+      warnings={[...(spWarnings ?? []), ...(credentialsWarnings ?? [])]}
       backPath={backPath}
     />
   );

--- a/apps/inspector/src/templates/DetailInfo.tsx
+++ b/apps/inspector/src/templates/DetailInfo.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@iconify/react";
 import { stringifyWithError } from "@originator-profile/core";
 import {
   _,
@@ -22,6 +23,7 @@ type DetailInfoProps = {
   cas?: SupportedVerifiedCas;
   framesCas?: FrameVerifiedCas[];
   errors: Error[];
+  warnings?: string[];
   backPath: {
     pathname: string;
     search: string;
@@ -34,6 +36,7 @@ function DetailInfo({
   cas,
   framesCas,
   errors,
+  warnings = [],
   backPath,
 }: DetailInfoProps) {
   const linkVerification = useLinkVerification();
@@ -79,6 +82,29 @@ function DetailInfo({
           <h2 className="pl-4 mb-4 text-sm font-bold text-gray-700">
             {_("DetailInfo")}
           </h2>
+          {warnings.length > 0 && (
+            <div className="pl-4 mb-8" data-testid="verification-warnings">
+              <h3 className="mb-4 text-sm font-bold text-gray-700">
+                {_("DetailInfo_Warnings")}
+              </h3>
+              <ul>
+                {warnings.map((warning, index) => (
+                  <li
+                    key={index}
+                    className="flex items-start mb-2 text-sm text-gray-700"
+                  >
+                    <Icon
+                      icon="ic:round-warning"
+                      className="size-5 mr-1 shrink-0 text-caution"
+                    />
+                    <span className="whitespace-pre-wrap break-all">
+                      {warning}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <JsonView
             className="pl-4 mb-8 overflow-auto"
             value={JSON.parse(

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -6,3 +6,4 @@ export * from "./keys";
 export * from "./originator-profile-set";
 export * from "./site-profile/";
 export * from "./verify-allowed-origin";
+export * from "./warn";

--- a/packages/verify/src/integrity/digest-sri.test.ts
+++ b/packages/verify/src/integrity/digest-sri.test.ts
@@ -168,4 +168,16 @@ describe("verifyImageDigestSri", () => {
     await verifyImageDigestSri(undefined, fetcher);
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  test("warn ハンドラーを指定した場合、console.warn の代わりに警告を受け取る", async () => {
+    const warnings: string[] = [];
+    await verifyImageDigestSri(
+      { id: "https://example.org/image.png" },
+      fetcher,
+      (message) => warnings.push(message),
+    );
+
+    expect(warnings).toEqual([expect.stringContaining("digestSRI is missing")]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/verify/src/integrity/digest-sri.test.ts
+++ b/packages/verify/src/integrity/digest-sri.test.ts
@@ -136,7 +136,7 @@ describe("verifyImageDigestSri", () => {
   test("digestSRI 検証に成功した場合、warn を出さない", async () => {
     await verifyImageDigestSri(
       { id: content.id, digestSRI: content.digestSRI },
-      fetcher,
+      { fetcher },
     );
 
     expect(warnSpy).not.toHaveBeenCalled();
@@ -145,7 +145,7 @@ describe("verifyImageDigestSri", () => {
   test("digestSRI 検証に失敗した場合、warn を出す", async () => {
     await verifyImageDigestSri(
       { id: content.id, digestSRI: content.digestSRI },
-      async () => new Response("wrong content"),
+      { fetcher: async () => new Response("wrong content") },
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
@@ -156,7 +156,7 @@ describe("verifyImageDigestSri", () => {
   test("digestSRI が存在しない場合、warn を出す", async () => {
     await verifyImageDigestSri(
       { id: "https://example.org/image.png" },
-      fetcher,
+      { fetcher },
     );
 
     expect(warnSpy).toHaveBeenCalledWith(
@@ -165,7 +165,7 @@ describe("verifyImageDigestSri", () => {
   });
 
   test("undefined の場合、何もしない", async () => {
-    await verifyImageDigestSri(undefined, fetcher);
+    await verifyImageDigestSri(undefined, { fetcher });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
@@ -173,8 +173,7 @@ describe("verifyImageDigestSri", () => {
     const warnings: string[] = [];
     await verifyImageDigestSri(
       { id: "https://example.org/image.png" },
-      fetcher,
-      (message) => warnings.push(message),
+      { fetcher, warn: (message) => warnings.push(message) },
     );
 
     expect(warnings).toEqual([expect.stringContaining("digestSRI is missing")]);

--- a/packages/verify/src/integrity/digest-sri.ts
+++ b/packages/verify/src/integrity/digest-sri.ts
@@ -4,6 +4,7 @@ import {
   type DigestSriResult,
 } from "@originator-profile/sign";
 import { IntegrityMetadataSet } from "websri";
+import type { WarnHandler } from "../warn";
 
 const WARN_SUFFIX = `This will become an error after 2027. See: https://docs.originator-profile.org/en/opb/context/#the-image-datatype`;
 
@@ -43,16 +44,17 @@ export async function verifyDigestSri(
 
 /**
  * Image の digestSRI を検証する。
- * 後方互換性の観点で、2027年までは検証失敗時に console.warn のみで処理を中断しない。
+ * 後方互換性の観点で、2027年までは検証失敗時に warn のみで処理を中断しない。
  */
 export async function verifyImageDigestSri(
   value: Image | undefined,
   fetcher = fetch,
+  warn: WarnHandler = console.warn,
 ): Promise<void> {
   if (!value) return;
 
   if (!value.digestSRI) {
-    console.warn(`digestSRI is missing. ${WARN_SUFFIX}`);
+    warn(`digestSRI is missing. ${WARN_SUFFIX}`);
     return;
   }
 
@@ -61,6 +63,6 @@ export async function verifyImageDigestSri(
     fetcher,
   );
   if (!valid) {
-    console.warn(`digestSRI verification failed. ${WARN_SUFFIX}`);
+    warn(`digestSRI verification failed. ${WARN_SUFFIX}`);
   }
 }

--- a/packages/verify/src/integrity/digest-sri.ts
+++ b/packages/verify/src/integrity/digest-sri.ts
@@ -48,9 +48,14 @@ export async function verifyDigestSri(
  */
 export async function verifyImageDigestSri(
   value: Image | undefined,
-  fetcher = fetch,
-  warn: WarnHandler = console.warn,
+  options: {
+    /** コンテンツの取得に用いる fetch 実装 */
+    fetcher?: typeof fetch;
+    /** 警告ハンドラー (デフォルト: `console.warn`) */
+    warn?: WarnHandler;
+  } = {},
 ): Promise<void> {
+  const { fetcher = fetch, warn = console.warn } = options;
   if (!value) return;
 
   if (!value.digestSRI) {

--- a/packages/verify/src/originator-profile-set/annotations.ts
+++ b/packages/verify/src/originator-profile-set/annotations.ts
@@ -43,9 +43,14 @@ function validateCertificateExpiry<T extends Certificate>(
 export async function verifyAnnotations(
   paIssuerKeys: MappedKeys,
   annotations?: UnverifiedJwtVc<Certificate>[],
-  validator?: typeof VcValidator,
-  warn?: WarnHandler,
+  options: {
+    /** バリデーター */
+    validator?: typeof VcValidator;
+    /** 警告ハンドラー (デフォルト: `console.warn`) */
+    warn?: WarnHandler;
+  } = {},
 ) {
+  const { validator, warn } = options;
   if (!annotations) return;
   return await Promise.all(
     annotations.map(async (annotation) => {
@@ -74,11 +79,7 @@ export async function verifyAnnotations(
         return valid;
       }
 
-      await verifyImageDigestSri(
-        valid.doc.credentialSubject.image,
-        undefined,
-        warn,
-      );
+      await verifyImageDigestSri(valid.doc.credentialSubject.image, { warn });
 
       return valid;
     }),

--- a/packages/verify/src/originator-profile-set/annotations.ts
+++ b/packages/verify/src/originator-profile-set/annotations.ts
@@ -13,6 +13,7 @@ import {
 import { z } from "zod";
 import { verifyImageDigestSri } from "../integrity";
 import { type MappedKeys } from "../keys";
+import type { WarnHandler } from "../warn";
 import { CertificateExpired } from "./errors";
 import { OpVerifier } from "./op-verifier";
 import type { Certificate } from "./types";
@@ -43,6 +44,7 @@ export async function verifyAnnotations(
   paIssuerKeys: MappedKeys,
   annotations?: UnverifiedJwtVc<Certificate>[],
   validator?: typeof VcValidator,
+  warn?: WarnHandler,
 ) {
   if (!annotations) return;
   return await Promise.all(
@@ -72,7 +74,11 @@ export async function verifyAnnotations(
         return valid;
       }
 
-      await verifyImageDigestSri(valid.doc.credentialSubject.image);
+      await verifyImageDigestSri(
+        valid.doc.credentialSubject.image,
+        undefined,
+        warn,
+      );
 
       return valid;
     }),

--- a/packages/verify/src/originator-profile-set/media.ts
+++ b/packages/verify/src/originator-profile-set/media.ts
@@ -12,9 +12,14 @@ import { OpVerifier } from "./op-verifier";
 export async function verifyMedia(
   wmpIssuerKeys: MappedKeys,
   media?: UnverifiedJwtVc<WebMediaProfile>[],
-  validator?: typeof VcValidator,
-  warn?: WarnHandler,
+  options: {
+    /** バリデーター */
+    validator?: typeof VcValidator;
+    /** 警告ハンドラー (デフォルト: `console.warn`) */
+    warn?: WarnHandler;
+  } = {},
 ) {
+  const { validator, warn } = options;
   if (!media) return;
   return await Promise.all(
     media.map(async (m) => {
@@ -28,11 +33,7 @@ export async function verifyMedia(
         return result;
       }
 
-      await verifyImageDigestSri(
-        result.doc.credentialSubject.logo,
-        undefined,
-        warn,
-      );
+      await verifyImageDigestSri(result.doc.credentialSubject.logo, { warn });
 
       return result;
     }),

--- a/packages/verify/src/originator-profile-set/media.ts
+++ b/packages/verify/src/originator-profile-set/media.ts
@@ -5,6 +5,7 @@ import {
 } from "@originator-profile/securing-mechanism";
 import { verifyImageDigestSri } from "../integrity";
 import { type MappedKeys } from "../keys";
+import type { WarnHandler } from "../warn";
 import { OpVerifier } from "./op-verifier";
 
 /** media プロパティの署名検証 */
@@ -12,6 +13,7 @@ export async function verifyMedia(
   wmpIssuerKeys: MappedKeys,
   media?: UnverifiedJwtVc<WebMediaProfile>[],
   validator?: typeof VcValidator,
+  warn?: WarnHandler,
 ) {
   if (!media) return;
   return await Promise.all(
@@ -26,7 +28,11 @@ export async function verifyMedia(
         return result;
       }
 
-      await verifyImageDigestSri(result.doc.credentialSubject.logo);
+      await verifyImageDigestSri(
+        result.doc.credentialSubject.logo,
+        undefined,
+        warn,
+      );
 
       return result;
     }),

--- a/packages/verify/src/originator-profile-set/pa-issuer-registration.test.ts
+++ b/packages/verify/src/originator-profile-set/pa-issuer-registration.test.ts
@@ -312,13 +312,9 @@ describe("Profile Annotation Issuer 登録証チェック", async () => {
     ];
 
     const warnings: string[] = [];
-    const result = await OpsVerifier(
-      target,
-      keys,
-      opId.authority,
-      undefined,
-      (message) => warnings.push(message),
-    )();
+    const result = await OpsVerifier(target, keys, opId.authority, {
+      warn: (message) => warnings.push(message),
+    })();
 
     expect(result).not.instanceOf(OpsInvalid);
     expect(result).not.instanceOf(OpsVerifyFailed);

--- a/packages/verify/src/originator-profile-set/pa-issuer-registration.test.ts
+++ b/packages/verify/src/originator-profile-set/pa-issuer-registration.test.ts
@@ -304,6 +304,30 @@ describe("Profile Annotation Issuer 登録証チェック", async () => {
     );
   });
 
+  test("warn ハンドラーを指定した場合、console.warn の代わりに警告を受け取る", async () => {
+    const target: OriginatorProfileSet = [
+      authorityOp,
+      certifierOp,
+      await originatorOpWithPa(),
+    ];
+
+    const warnings: string[] = [];
+    const result = await OpsVerifier(
+      target,
+      keys,
+      opId.authority,
+      undefined,
+      (message) => warnings.push(message),
+    )();
+
+    expect(result).not.instanceOf(OpsInvalid);
+    expect(result).not.instanceOf(OpsVerifyFailed);
+    expect(warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining(NOT_REGISTERED)]),
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   test("Core Profile Issuer が自己宛に発行した登録証は基底となる", async () => {
     const target: OriginatorProfileSet = [
       {

--- a/packages/verify/src/originator-profile-set/pa-issuer-registration.ts
+++ b/packages/verify/src/originator-profile-set/pa-issuer-registration.ts
@@ -4,6 +4,7 @@ import {
   ProfileAnnotationPolicy,
 } from "@originator-profile/model";
 import { VerifiedJwtVc } from "@originator-profile/securing-mechanism";
+import type { WarnHandler } from "../warn";
 import type { Certificate, VerifiedOps } from "./types";
 
 /** 認可された Profile Annotation Policy ID の集合 */
@@ -68,6 +69,7 @@ function reportUnauthorizedAnnotation({
   paIndex,
   policy,
   cpIssuers,
+  warn,
 }: {
   /** 対象の PA */
   annotation: VerifiedJwtVc<Certificate>;
@@ -79,13 +81,15 @@ function reportUnauthorizedAnnotation({
   policy: ProfileAnnotationPolicyMap;
   /** Core Profile Issuer の OP ID の集合 */
   cpIssuers: ReadonlySet<string>;
+  /** 警告ハンドラー */
+  warn: WarnHandler;
 }): void {
   const { doc } = annotation;
   const { issuer: profileAnnotationIssuer } = doc;
   const location = `OP[${opIndex}].PA[${paIndex}]`;
 
   if (!isProfileAnnotation(doc)) {
-    console.warn(`Certificate is deprecated (${location})`);
+    warn(`Certificate is deprecated (${location})`);
     return;
   }
 
@@ -100,7 +104,7 @@ function reportUnauthorizedAnnotation({
   const isAllowed =
     policyId && policy.get(profileAnnotationIssuer)?.has(policyId);
   if (!isAllowed) {
-    console.warn(
+    warn(
       `Profile Annotation Issuer is not registered for this annotation scheme (${location} issuer: ${profileAnnotationIssuer}, scheme: ${policyId ?? "unknown"})`,
     );
   }
@@ -111,16 +115,18 @@ function reportUnauthorizedAnnotation({
  *
  * 各 Profile Annotation の発行者が、Core Profile Issuer から発行された登録証 PA によって、その PA が準拠する 認証制度（Profile Annotation Policy）の発行を認可されているかを検証
  *
- * (2027年まで) 後方互換性のため、認可を確認できない場合も検証は失敗させず console.warn に留める。
+ * (2027年まで) 後方互換性のため、認可を確認できない場合も検証は失敗させず warn に留める。
  *
  * @param verifiedOps 検証済み Originator Profile Set
  * @param cpIssuer 基底となる Core Profile Issuer の OP ID
+ * @param warn 警告ハンドラー (デフォルト: `console.warn`)
  *
  * @see https://docs.originator-profile.org/opb/pa-model/profile-annotation-issuer-registration/
  */
 export function verifyAnnotationIssuerRegistration(
   verifiedOps: VerifiedOps,
   cpIssuer: string | string[],
+  warn: WarnHandler = console.warn,
 ): VerifiedOps {
   const cpIssuers = new Set([cpIssuer].flat());
   const policy = buildProfileAnnotationPolicy(verifiedOps, cpIssuers);
@@ -132,6 +138,7 @@ export function verifyAnnotationIssuerRegistration(
         paIndex,
         policy,
         cpIssuers,
+        warn,
       });
     }
   }

--- a/packages/verify/src/originator-profile-set/verify-ops.ts
+++ b/packages/verify/src/originator-profile-set/verify-ops.ts
@@ -58,17 +58,21 @@ const isVerifiedOps = (ops: OpVerificationResult[]): ops is VerifiedOps =>
  * @param ops Originator Profile Set
  * @param keys Core Profile の発行者の検証鍵
  * @param issuer Core Profile の発行者
- * @param validator バリデーター
- * @param warn 警告ハンドラー (デフォルト: `console.warn`)
+ * @param options バリデーターと警告ハンドラー
  * @returns 検証者
  */
 export function OpsVerifier(
   ops: OriginatorProfileSet,
   keys: Keys,
   issuer: string | string[],
-  validator?: typeof VcValidator,
-  warn?: WarnHandler,
+  options: {
+    /** バリデーター */
+    validator?: typeof VcValidator;
+    /** 警告ハンドラー (デフォルト: `console.warn`) */
+    warn?: WarnHandler;
+  } = {},
 ) {
+  const { validator, warn } = options;
   const decoded = decodeOps(ops);
   const verifyCp = JwtVcVerifier<CoreProfile>(
     keys,
@@ -91,15 +95,12 @@ export function OpsVerifier(
         const annotations = await verifyAnnotations(
           paOrWmpIssuerKeys,
           op.annotations,
+          { validator, warn },
+        );
+        const media = await verifyMedia(paOrWmpIssuerKeys, op.media, {
           validator,
           warn,
-        );
-        const media = await verifyMedia(
-          paOrWmpIssuerKeys,
-          op.media,
-          validator,
-          warn,
-        );
+        });
         const resultOp = { core, annotations, media };
 
         if (core instanceof Error) {

--- a/packages/verify/src/originator-profile-set/verify-ops.ts
+++ b/packages/verify/src/originator-profile-set/verify-ops.ts
@@ -5,6 +5,7 @@ import {
   VcValidator,
 } from "@originator-profile/securing-mechanism";
 import { getMappedKeys } from "../keys";
+import type { WarnHandler } from "../warn";
 import { verifyAnnotations } from "./annotations";
 import { decodeOps } from "./decode-ops";
 import { OpsInvalid, OpsVerifyFailed, OpVerifyFailed } from "./errors";
@@ -58,6 +59,7 @@ const isVerifiedOps = (ops: OpVerificationResult[]): ops is VerifiedOps =>
  * @param keys Core Profile の発行者の検証鍵
  * @param issuer Core Profile の発行者
  * @param validator バリデーター
+ * @param warn 警告ハンドラー (デフォルト: `console.warn`)
  * @returns 検証者
  */
 export function OpsVerifier(
@@ -65,6 +67,7 @@ export function OpsVerifier(
   keys: Keys,
   issuer: string | string[],
   validator?: typeof VcValidator,
+  warn?: WarnHandler,
 ) {
   const decoded = decodeOps(ops);
   const verifyCp = JwtVcVerifier<CoreProfile>(
@@ -89,8 +92,14 @@ export function OpsVerifier(
           paOrWmpIssuerKeys,
           op.annotations,
           validator,
+          warn,
         );
-        const media = await verifyMedia(paOrWmpIssuerKeys, op.media, validator);
+        const media = await verifyMedia(
+          paOrWmpIssuerKeys,
+          op.media,
+          validator,
+          warn,
+        );
         const resultOp = { core, annotations, media };
 
         if (core instanceof Error) {
@@ -137,7 +146,7 @@ export function OpsVerifier(
       return new OpsVerifyFailed(msg, resultOps);
     }
 
-    return verifyAnnotationIssuerRegistration(resultOps, issuer);
+    return verifyAnnotationIssuerRegistration(resultOps, issuer, warn);
   }
   return verify;
 }

--- a/packages/verify/src/site-profile/verify-site-profile.test.ts
+++ b/packages/verify/src/site-profile/verify-site-profile.test.ts
@@ -162,8 +162,7 @@ describe("Site Profileの検証", async () => {
       LocalKeys({ keys: [authority.publicKey] }),
       opId.authority,
       "https://originator.example.org",
-      true,
-      VcValidator,
+      { validator: VcValidator },
     );
     const resultSp = await verify();
 
@@ -228,7 +227,7 @@ describe("Site Profileの検証", async () => {
       LocalKeys({ keys: [authority.publicKey] }),
       opId.authority,
       "https://not-exisiting.example.org",
-      false,
+      { verifyOrigin: false },
     );
     const resultSp = await verify();
 
@@ -304,8 +303,7 @@ describe("Site Profileの検証", async () => {
       LocalKeys({ keys: [authority.publicKey] }),
       opId.authority,
       "https://originator.example.org",
-      true,
-      VcValidator,
+      { validator: VcValidator },
     );
     const resultSp = await verify();
 

--- a/packages/verify/src/site-profile/verify-site-profile.ts
+++ b/packages/verify/src/site-profile/verify-site-profile.ts
@@ -21,6 +21,7 @@ import {
 import { VerifiedOps } from "../originator-profile-set/types";
 import { OpsVerifier } from "../originator-profile-set/verify-ops";
 import { verifyAllowedOrigin } from "../verify-allowed-origin";
+import type { WarnHandler } from "../warn";
 import { SpVerificationResult } from "./types";
 import { SiteProfileInvalid, SiteProfileVerifyFailed } from "./verify-errors";
 
@@ -66,6 +67,7 @@ const decodeWebsiteProfiles = (
  * @param origin 提示するWebサイトを識別するための RFC 6454 オリジン
  * @param verifyOrigin WSPが提示されたWebサイトのorigin引数との一致性検証の可否 (デフォルト: 有効)
  * @param validator バリデーター
+ * @param warn 警告ハンドラー (デフォルト: `console.warn`)
  * @returns 検証者
  */
 export function SpVerifier(
@@ -75,9 +77,16 @@ export function SpVerifier(
   origin: URL["origin"],
   verifyOrigin = true,
   validator?: typeof VcValidator,
+  warn?: WarnHandler,
 ) {
   async function verify(): Promise<SpVerificationResult> {
-    const verifyOps = OpsVerifier(sp.originators, keys, issuer, validator);
+    const verifyOps = OpsVerifier(
+      sp.originators,
+      keys,
+      issuer,
+      validator,
+      warn,
+    );
     const opsVerified = await verifyOps();
     if (opsVerified instanceof OpsInvalid) {
       return new SiteProfileInvalid("Originator Profile Set invalid", {
@@ -138,7 +147,11 @@ export function SpVerifier(
           }
         }
 
-        await verifyImageDigestSri(verified.doc.credentialSubject.image);
+        await verifyImageDigestSri(
+          verified.doc.credentialSubject.image,
+          undefined,
+          warn,
+        );
 
         return verified;
       }),

--- a/packages/verify/src/site-profile/verify-site-profile.ts
+++ b/packages/verify/src/site-profile/verify-site-profile.ts
@@ -65,9 +65,7 @@ const decodeWebsiteProfiles = (
  * @param keys Core Profile の発行者の検証鍵
  * @param issuer Core Profile の発行者
  * @param origin 提示するWebサイトを識別するための RFC 6454 オリジン
- * @param verifyOrigin WSPが提示されたWebサイトのorigin引数との一致性検証の可否 (デフォルト: 有効)
- * @param validator バリデーター
- * @param warn 警告ハンドラー (デフォルト: `console.warn`)
+ * @param options オリジン検証の可否・バリデーター・警告ハンドラー
  * @returns 検証者
  */
 export function SpVerifier(
@@ -75,18 +73,21 @@ export function SpVerifier(
   keys: Keys,
   issuer: string | string[],
   origin: URL["origin"],
-  verifyOrigin = true,
-  validator?: typeof VcValidator,
-  warn?: WarnHandler,
+  options: {
+    /** WSPが提示されたWebサイトのorigin引数との一致性検証の可否 (デフォルト: 有効) */
+    verifyOrigin?: boolean;
+    /** バリデーター */
+    validator?: typeof VcValidator;
+    /** 警告ハンドラー (デフォルト: `console.warn`) */
+    warn?: WarnHandler;
+  } = {},
 ) {
+  const { verifyOrigin = true, validator, warn } = options;
   async function verify(): Promise<SpVerificationResult> {
-    const verifyOps = OpsVerifier(
-      sp.originators,
-      keys,
-      issuer,
+    const verifyOps = OpsVerifier(sp.originators, keys, issuer, {
       validator,
       warn,
-    );
+    });
     const opsVerified = await verifyOps();
     if (opsVerified instanceof OpsInvalid) {
       return new SiteProfileInvalid("Originator Profile Set invalid", {
@@ -147,11 +148,9 @@ export function SpVerifier(
           }
         }
 
-        await verifyImageDigestSri(
-          verified.doc.credentialSubject.image,
-          undefined,
+        await verifyImageDigestSri(verified.doc.credentialSubject.image, {
           warn,
-        );
+        });
 
         return verified;
       }),

--- a/packages/verify/src/warn.ts
+++ b/packages/verify/src/warn.ts
@@ -1,0 +1,8 @@
+/**
+ * 検証中の警告メッセージを受け取るハンドラー
+ *
+ * 検証を失敗とはしない後方互換性のための警告 (非推奨 Certificate や
+ * digestSRI の欠落・不一致など) の通知に使用する。
+ * デフォルトは `console.warn`。
+ */
+export type WarnHandler = (message: string) => void;


### PR DESCRIPTION
## 変更内容

verify パッケージが `console.warn` に出力していた後方互換性のための警告 (非推奨 Certificate・PA 発行者未登録・digestSRI 欠落/不一致) を、inspector の「詳細情報」(/detail) 画面でも確認できるようにしました。

- **packages/verify**: 警告出力を差し替え可能な `WarnHandler` を導入 (デフォルトは従来どおり `console.warn`)。`OpsVerifier` / `SpVerifier` / `verifyAnnotationIssuerRegistration` / `verifyImageDigestSri` などに配線
- **apps/inspector**: `useCredentials` / `useSiteProfile` が検証中の警告を `warnings` として返し、詳細情報セクション内に警告一覧を表示 (i18n キー `DetailInfo_Warnings` を ja/en に追加)。コンソールへの出力は維持
- **refactor(verify)!**: 末尾のオプション引数群 (`validator` / `verifyOrigin` / `fetcher` / `warn`) をオプションオブジェクトに変更し、`undefined` 埋めの呼び出しを解消
  - `verifyImageDigestSri(value, { fetcher?, warn? })`
  - `verifyAnnotations` / `verifyMedia(keys, items?, { validator?, warn? })`
  - `OpsVerifier(ops, keys, issuer, { validator?, warn? })`
  - `SpVerifier(sp, keys, issuer, origin, { verifyOrigin?, validator?, warn? })`
- **refactor(inspector)**: `sp_error` / `credentials_error` などの snake_case 変数を camelCase に統一

**BREAKING CHANGE**: `validator` / `verifyOrigin` を位置引数で渡している呼び出しはオプションオブジェクトへの移行が必要です (リポジトリ内の呼び出しは移行済み)。

**残課題**: CAS 検証経路 (`verify-content-attestation.ts`) の `verifyImageDigestSri` には warn を未配線のため、CA image の digestSRI 警告はコンソールにのみ出力されます。

## 確認手順

- `packages/verify`: `pnpm test` (134件、warn ハンドラー収集のテストを追加) / `pnpm type-check` / `pnpm build`
- `apps/inspector`: `pnpm test` (41件) / `pnpm type-check` / e2e に「詳細情報画面に検証中の警告ログが表示される」を追加し site-profile 系スイートがパス
- 手動確認: 拡張機能を読み込み、digestSRI の無い image を含む Site Profile を提示するページで詳細情報画面を開くと、「詳細情報」セクション内に警告 (digestSRI is missing...) が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)