### PR TITLE
docs: 公開パッケージの README に npm version / jsDocs.io バッジを追加

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,5 @@
 # Profile Core
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/core)](https://www.npmjs.com/package/@originator-profile/core) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/core)
+
 システムのコアとなる関数のためのパッケージです。

--- a/packages/cryptography/README.md
+++ b/packages/cryptography/README.md
@@ -1,3 +1,5 @@
 # Profile Cryptography
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/cryptography)](https://www.npmjs.com/package/@originator-profile/cryptography) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/cryptography)
+
 暗号処理をするためのパッケージです。

--- a/packages/model/README.md
+++ b/packages/model/README.md
@@ -1,5 +1,7 @@
 # Originator Profile Model
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/model)](https://www.npmjs.com/package/@originator-profile/model) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/model)
+
 システムのコアとなる静的構造のためのパッケージです。
 
 ## ドキュメント

--- a/packages/opvc/README.md
+++ b/packages/opvc/README.md
@@ -1,5 +1,7 @@
 # opvc - Originator Profile Verifiable Credential command line tool
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/opvc)](https://www.npmjs.com/package/@originator-profile/opvc) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/opvc)
+
 Originator Profile (OP) 仕様に準拠した Verifiable Credential (VC) を作成・管理するためのツールです。
 
 <!-- prettier-ignore-start -->

--- a/packages/presentation/README.md
+++ b/packages/presentation/README.md
@@ -1,3 +1,5 @@
 # Profile Presentation
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/presentation)](https://www.npmjs.com/package/@originator-profile/presentation) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/presentation)
+
 OP や CA を提示するためのパッケージです。

--- a/packages/securing-mechanism/README.md
+++ b/packages/securing-mechanism/README.md
@@ -1,3 +1,5 @@
 # Profile JWT Securing Mechanism
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/securing-mechanism)](https://www.npmjs.com/package/@originator-profile/securing-mechanism) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/securing-mechanism)
+
 VC の Securing 処理をするためのパッケージです。

--- a/packages/sign/README.md
+++ b/packages/sign/README.md
@@ -1,3 +1,5 @@
 # Profile Sign
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/sign)](https://www.npmjs.com/package/@originator-profile/sign) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/sign)
+
 鍵の生成と署名するためのパッケージです。

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -1,5 +1,7 @@
 # Profile Verify
 
+[![npm version](https://img.shields.io/npm/v/@originator-profile/verify)](https://www.npmjs.com/package/@originator-profile/verify) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/verify)
+
 署名を検証するためのパッケージです。
 
 <!-- prettier-ignore-start -->

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,6 +1,6 @@
 # @originator-profile/vite-plugin
 
-[![npm version](https://img.shields.io/npm/v/@originator-profile/vite-plugin)](https://www.npmjs.com/package/@originator-profile/vite-plugin)
+[![npm version](https://img.shields.io/npm/v/@originator-profile/vite-plugin)](https://www.npmjs.com/package/@originator-profile/vite-plugin) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/vite-plugin)
 
 Vite plugin that signs [Website Profiles](https://docs.originator-profile.org/en/opb/site-profile/) (WSP) and [Content Attestations](https://docs.originator-profile.org/en/opb/content-attestation/) (CA) at build time.
 


### PR DESCRIPTION
## 概要

npm に公開している 9 パッケージの README に、npm version バッジと jsDocs.io バッジを追加しました。

- 対象: core, cryptography, model, opvc, presentation, securing-mechanism, sign, verify, vite-plugin
- vite-plugin には既に npm version バッジがあったため、jsDocs.io バッジのみ追記し、他 8 パッケージは同じ「npm version + jsDocs.io」の並びで統一しています
- private パッケージ（ui, wordpress, tsconfig など）は対象外です

## 表示例

[![npm version](https://img.shields.io/npm/v/@originator-profile/opvc)](https://www.npmjs.com/package/@originator-profile/opvc) [![jsDocs.io](https://img.shields.io/badge/jsDocs.io-reference-blue)](https://www.jsdocs.io/package/@originator-profile/opvc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)