### PR TITLE
feat(opvc): CA server 署名で CA ID を server 採番に委ねられるようにする

### DIFF
--- a/packages/model/src/content-attestation/unsigned-content-attestation.ts
+++ b/packages/model/src/content-attestation/unsigned-content-attestation.ts
@@ -14,7 +14,13 @@ export const UnsignedContentAttestation = z.looseObject({
       error: `type must include "ContentAttestation"`,
     }),
   issuer: OpId,
-  credentialSubject: subject,
+  credentialSubject: subject.extend({
+    id: subject.shape.id
+      .describe(
+        "CA ID. Omit to mint a new CA (the ID is assigned at signing time); provide the ID of an existing CA to sign it.",
+      )
+      .optional(),
+  }),
   allowedUrl: AllowedUrl.optional(),
   allowedOrigin: AllowedOrigin.optional(),
   target: z.array(RawTarget).min(1),

--- a/packages/opvc/src/content-attestation.test.ts
+++ b/packages/opvc/src/content-attestation.test.ts
@@ -428,6 +428,33 @@ await describe("signByServer()", async () => {
     assert.strictEqual(body.expiredAt, expiredAt.toISOString());
   });
 
+  await test("credentialSubject.id が未指定なら fill せず sub なしで送信する", async () => {
+    endpointResponse = async () =>
+      new Response(JSON.stringify(["jwt-1"]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const uca = createUnsignedContentAttestation();
+    delete uca.credentialSubject.id;
+
+    await signByServer(uca, {
+      endpoint,
+      accessToken: "test-access-token",
+    });
+
+    const requestBody = request?.init?.body;
+    if (typeof requestBody !== "string") {
+      throw new TypeError("Expected request body to be a JSON string.");
+    }
+    const body = JSON.parse(requestBody) as {
+      sub?: string;
+      credentialSubject: { id?: string };
+    };
+    assert.strictEqual(body.sub, undefined);
+    assert.strictEqual(body.credentialSubject.id, undefined);
+  });
+
   await test("CA server が文字列 JWT を直接返した場合はそのまま返す", async () => {
     endpointResponse = async () =>
       new Response("jwt-direct", {

--- a/packages/opvc/src/content-attestation.ts
+++ b/packages/opvc/src/content-attestation.ts
@@ -19,9 +19,9 @@ type UnsignedCaOptions = TimingOptions & {
   documentProvider?: DocumentProvider;
   /**
    * 入力に credentialSubject.id が無い場合に urn:uuid を採番するか。
-   * @default false
+   * @default true
    */
-  assignId?: true;
+  assignId?: boolean;
 };
 
 /**

--- a/packages/opvc/src/content-attestation.ts
+++ b/packages/opvc/src/content-attestation.ts
@@ -17,6 +17,11 @@ import { parseDates, type TimingOptions } from "./timing-options.ts";
 type UnsignedCaOptions = TimingOptions & {
   integrityAlg?: HashAlgorithm;
   documentProvider?: DocumentProvider;
+  /**
+   * 入力に credentialSubject.id が無い場合に urn:uuid を採番するか。
+   * @default false
+   */
+  assignId?: true;
 };
 
 /**
@@ -30,11 +35,14 @@ export async function unsignedCa(
   {
     integrityAlg = "sha256",
     documentProvider = defaultDocumentProvider,
+    assignId = true,
     ...timingOptions
   }: UnsignedCaOptions,
 ): Promise<UnsignedContentAttestation> {
   const { issuedAt, expiredAt } = parseDates(timingOptions);
-  uca.credentialSubject.id ??= `urn:uuid:${crypto.randomUUID()}`;
+  if (assignId) {
+    uca.credentialSubject.id ??= `urn:uuid:${crypto.randomUUID()}`;
+  }
 
   try {
     UnsignedContentAttestation.parse(uca);
@@ -98,7 +106,12 @@ export async function signByServer(
   },
 ): Promise<string> {
   const { issuedAt, expiredAt } = parseDates(options);
-  const payload = await unsignedCa(uca, { ...options, issuedAt, expiredAt });
+  const payload = await unsignedCa(uca, {
+    ...options,
+    issuedAt,
+    expiredAt,
+    assignId: false,
+  });
 
   const response = await fetch(endpoint, {
     method: "POST",

--- a/packages/sign/src/sign-ca.ts
+++ b/packages/sign/src/sign-ca.ts
@@ -36,5 +36,16 @@ export async function signCa(
   await fetchAndSetDigestSri(integrityAlg, uca.credentialSubject.image);
   await fetchAndSetTargetIntegrity(integrityAlg, uca, documentProvider);
 
-  return await signJwtVc(uca, privateKey, { alg, issuedAt, expiredAt });
+  const { id } = uca.credentialSubject;
+  if (id === undefined) {
+    throw new Error(
+      "credentialSubject.id is required to sign a Content Attestation.",
+    );
+  }
+
+  return await signJwtVc(
+    { ...uca, credentialSubject: { ...uca.credentialSubject, id } },
+    privateKey,
+    { alg, issuedAt, expiredAt },
+  );
 }


### PR DESCRIPTION
## 概要

`UnsignedContentAttestation` の `credentialSubject.id` を任意にし、`opvc.signByServer` では入力に `credentialSubject.id` が指定されていなければ fill せず未定義のまま CA server に送信するようにします。CA server 側が CA ID を採番する運用に対応するための変更です。

## 変更内容

### model — `unsigned-content-attestation.ts`
- 共有 `subject`（署名済み `ContentAttestation` も使用）はそのままに、`UnsignedContentAttestation` 側だけ `subject.extend({ id: ...optional() })` で `id` を任意化。
- セマンティクスは `.describe()` で文書化：**省略時＝新規CA（署名時に採番）／指定時＝既存CAのID**。`z.url()` の検証は保持。

### opvc — `content-attestation.ts`
- `UnsignedCaOptions` に `assignId?: boolean`（デフォルト `true`）を追加。
- `unsignedCa` の `id ??= urn:uuid...` を `assignId` で条件化。既存の `sign` / `ca unsigned` コマンドの挙動は不変。
- `signByServer` は `assignId: false` を渡し、id 未指定なら fill せず未定義のまま送信（`sub` も送らない）。

### sign — `sign-ca.ts`
- モデルの id 任意化に伴い、ローカル署名 (`signJwtVc` は `credentialSubject.id: string` を要求) で型の整合を取る必要があるため、id 存在ガードを追加。ローカル署名では JWT の `sub` に id が必須のため、未指定時は明示的にエラーとする。

## テスト
- `signByServer()` に「`credentialSubject.id` が未指定なら fill せず `sub` なしで送信する」を追加。
- 影響パッケージ（model / opvc / sign / vite-plugin）の type-check・test・lint がすべて通過。

## 設計上の判断
- `signByServer` だけに影響を限定するため、`unsignedCa` から採番を削除するのではなく `assignId` オプションで opt-out する形にしました（`sign`・`ca unsigned` コマンドは従来どおり自動採番）。
- 共有 `subject` を直接任意にすると署名済み `ContentAttestation` の id まで緩むため、`.extend` で `UnsignedContentAttestation` 側のみに限定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)