### PR TITLE
chore: type-check タスクを削除し oxlint typeCheck に統合

### DIFF
--- a/.github/actions/type-check/action.yml
+++ b/.github/actions/type-check/action.yml
@@ -1,7 +1,0 @@
-name: type-check
-description: Type Check
-runs:
-  using: composite
-  steps:
-    - run: pnpm type-check
-      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
         uses: "./.github/actions/format"
       - name: Lint
         uses: "./.github/actions/lint"
-      - name: Type Check
-        uses: "./.github/actions/type-check"
       - name: Test
         uses: "./.github/actions/test"
       - name: Testing Build

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,8 @@
     "correctness": "off"
   },
   "options": {
-    "typeAware": true
+    "typeAware": true,
+    "typeCheck": true
   },
   "env": {
     "builtin": true

--- a/apps/inspector/package.json
+++ b/apps/inspector/package.json
@@ -59,7 +59,6 @@
     "tailwind-merge": "3.5.0",
     "tailwindcss": "4.2.2",
     "typed-url-params": "1.0.1",
-    "typescript": "6.0.2",
     "use-debounce": "10.1.1",
     "vitest": "4.1.4",
     "web-ext": "10.1.0",

--- a/apps/inspector/package.json
+++ b/apps/inspector/package.json
@@ -82,7 +82,6 @@
     "e2e:en:update": "LC_ALL=en_US.UTF-8 playwright test --project=en --update-snapshots",
     "test": "vitest run",
     "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit",
     "presubmit": "git -C ../.. archive --format=zip --output=apps/inspector/web-ext-artifacts/sources.zip HEAD",
     "submit": "wxt submit --chrome-zip web-ext-artifacts/op_inspector-chromium-*.zip --firefox-zip web-ext-artifacts/op_inspector-firefox-desktop-*.zip --firefox-sources-zip web-ext-artifacts/sources.zip"
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "e2e:update": "turbo run e2e:update --concurrency=1 --filter=!@originator-profile/wordpress",
     "test": "turbo run test --continue",
     "lint": "turbo run lint --continue",
-    "type-check": "turbo run type-check --continue",
     "format": "prettier --write .",
     "update": "run-s update:pnpm update:dedupe",
     "update:pnpm": "pnpm --recursive update --latest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "devDependencies": {
     "@js-temporal/polyfill": "0.5.1",

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/model": "workspace:*",

--- a/packages/demo-page/package.json
+++ b/packages/demo-page/package.json
@@ -14,8 +14,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.31.2",

--- a/packages/demo-page/package.json
+++ b/packages/demo-page/package.json
@@ -25,7 +25,6 @@
     "globals": "17.5.0",
     "oxlint": "^1.73.0",
     "oxlint-tsgolint": "^0.24.0",
-    "typescript": "6.0.2",
     "vite": "8.0.8",
     "wrangler": "4.81.1"
   },

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "websri": "^1.0.1",

--- a/packages/opvc/package.json
+++ b/packages/opvc/package.json
@@ -36,7 +36,6 @@
   "scripts": {
     "build": "tsdown && oclif manifest && oclif readme",
     "lint": "oxlint --fix .",
-    "type-check": "tsc",
     "test": "node --test"
   },
   "dependencies": {

--- a/packages/presentation/package.json
+++ b/packages/presentation/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/model": "workspace:*"

--- a/packages/securing-mechanism/package.json
+++ b/packages/securing-mechanism/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/cryptography": "workspace:*",

--- a/packages/sign/package.json
+++ b/packages/sign/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/cryptography": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,6 @@
     "swr": "2.4.1",
     "tailwind-config-originator-profile": "workspace:*",
     "tailwind-merge": "3.5.0",
-    "typescript": "6.0.2",
     "vitest": "4.1.4"
   },
   "peerDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,8 +20,7 @@
   },
   "scripts": {
     "lint": "oxlint --fix .",
-    "test": "vitest run",
-    "type-check": "tsc --noEmit"
+    "test": "vitest run"
   },
   "devDependencies": {
     "@iconify/react": "6.0.2",

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -27,8 +27,7 @@
     "test": "vitest run",
     "e2e": "playwright test",
     "e2e:update": "playwright test --update-snapshots",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/core": "workspace:*",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "build": "pkgroll --clean-dist",
     "test": "vitest run",
-    "lint": "oxlint --fix .",
-    "type-check": "tsc --noEmit"
+    "lint": "oxlint --fix ."
   },
   "dependencies": {
     "@originator-profile/model": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       typed-url-params:
         specifier: 1.0.1
         version: 1.0.1
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
       use-debounce:
         specifier: 10.1.1
         version: 10.1.1(react@19.2.6)
@@ -317,9 +314,6 @@ importers:
       oxlint-tsgolint:
         specifier: ^0.24.0
         version: 0.24.0
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
       vite:
         specifier: 8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3)
@@ -602,9 +596,6 @@ importers:
       tailwind-merge:
         specifier: 3.5.0
         version: 3.5.0
-      typescript:
-        specifier: 6.0.2
-        version: 6.0.2
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@types/node@25.6.0)(happy-dom@20.8.9)(jsdom@29.0.2)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.2))(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.3))

--- a/turbo.json
+++ b/turbo.json
@@ -32,10 +32,6 @@
       "dependsOn": ["build"],
       "outputs": []
     },
-    "type-check": {
-      "dependsOn": ["build"],
-      "outputs": []
-    },
     "@originator-profile/inspector#build": {
       "dependsOn": ["^build"],
       "env": [


### PR DESCRIPTION
## 変更内容

各パッケージの独立した `type-check` スクリプト（`tsc --noEmit` / `tsc`）、ルート `package.json` の `type-check` スクリプト、`turbo.json` の `type-check` タスク、`.github/actions/type-check/` および CI (`test.yml`) の Type Check ステップを削除。

oxlint の `typeAware` はすでに有効化されていたが、`tsc` 相当のコンパイラ診断（型不一致など）までは検出していなかった。ルートの `.oxlintrc.json` に `options.typeCheck: true` を追加することで、`lint`（`oxlint --fix .`）実行時に型チェックも一括して行われるようになり、独立した `type-check` ステップが不要になったため削除した。

## 確認手順

- 意図的に型エラーを仕込んだファイルを追加し、`pnpm oxlint .` が `typescript(TS2322)` のようなコンパイラ診断を検出して失敗することを確認済み
- `pnpm lint`（`turbo run lint`）をモノレポ全体で実行し、24 タスクすべてが成功することを確認済み