### PR TITLE
chore(inspector): AMO 提出用の build-for-amo スクリプトを追加

### DIFF
--- a/apps/inspector/README.md
+++ b/apps/inspector/README.md
@@ -139,6 +139,8 @@ $ REGISTRY_OPS=$(cat registry-ops.json) pnpm build
 - `pnpm e2e:update`: Visual Regression Testのベースライン画像を更新します。CIと環境の差分があるため、GitHub Actions（"Update VRT Baselines" ワークフロー）での実行を推奨します。
   - `pnpm e2e:ja:update`: 日本語UIのベースライン画像のみ更新
   - `pnpm e2e:en:update`: 英語UIのベースライン画像のみ更新（※現状、英語UIのVRTテストは未実装です。日本語UIのみVRTテストが実装されています）
+- `pnpm build-for-amo`: [addons.mozilla.org](https://addons.mozilla.org/) への提出に必要な成果物一式（Firefox 向けビルドと、審査でコードの照合に使われるソースコード一式の zip）を `web-ext-artifacts/` に生成します。
+- `pnpm submit`: ビルド済みの成果物を Chrome ウェブストアおよび AMO に提出します（`FIREFOX_JWT_ISSUER` 等の認証情報が必要です）。
 
 ## ドキュメント
 

--- a/apps/inspector/package.json
+++ b/apps/inspector/package.json
@@ -83,6 +83,7 @@
     "test": "vitest run",
     "lint": "oxlint --fix .",
     "type-check": "tsc --noEmit",
+    "build-for-amo": "run-s build:firefox presubmit",
     "presubmit": "git -C ../.. archive --format=zip --output=apps/inspector/web-ext-artifacts/sources.zip HEAD",
     "submit": "wxt submit --chrome-zip web-ext-artifacts/op_inspector-chromium-*.zip --firefox-zip web-ext-artifacts/op_inspector-firefox-desktop-*.zip --firefox-sources-zip web-ext-artifacts/sources.zip"
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "turbo run build",
+    "build-for-amo": "pnpm --dir=apps/inspector run build-for-amo",
     "version": "node --run=build && node scripts/update-readme-environments.ts && git add apps/*/README.md packages/*/README.md",
     "dev": "turbo run dev --parallel --env-mode=loose",
     "e2e": "turbo run e2e --concurrency=1 --filter=!@originator-profile/wordpress",


### PR DESCRIPTION
## 変更内容

Mozilla の公式ブログ「[Firefox 153 WebExtensions API updates](https://blog.mozilla.org/addons/2026/07/23/firefox-153-webextensions-api-updates/)」で案内されているとおり、AMO への提出では、ビルド済みの拡張機能 zip に加えて、コードが esbuild によってバンドル・minify されているため、レビュー担当者がソースコードと照合できるようビルド方法を伝える必要があります。そのための `build-for-amo` スクリプトを定義しました。

- `apps/inspector/package.json`: `build-for-amo`（`run-s build:firefox presubmit`）を追加。Firefox 向けビルドと AMO 審査用ソースコード zip を `web-ext-artifacts/` にまとめて生成します。
- `apps/inspector/README.md`: 追加したスクリプトの説明を追記しました。
- ルート `package.json`: `pnpm --dir=apps/inspector run build-for-amo` を呼び出す `build-for-amo` を追加し、リポジトリルートからも実行できるようにしました。

## 確認手順

1. `pnpm --dir=apps/inspector run build-for-amo`（もしくはルートで `pnpm build-for-amo`）を実行する。
2. `apps/inspector/web-ext-artifacts/` に Firefox 向け拡張機能 zip（`op_inspector-firefox-desktop-*.zip`）と、ソースコード zip（`sources.zip`）が生成されることを確認する。