### PR TITLE
feat(wordpress): 画像の署名が失敗するケースに関してログの追加

### DIFF
--- a/packages/wordpress/README.md
+++ b/packages/wordpress/README.md
@@ -399,16 +399,18 @@ Pro版では、画像がCDN経由で変換され、URLが変化する場合が�
 
 **回避策**： 一度記事を非公開にすることで、メタデータがクリアされます。その後再度公開することで UUID を指定しない新規登録となり、正常に登録されます。
 
-### 他の投稿に添付済みの画像を再利用した場合、Integrityが生成されないことがある
+### 他の投稿に添付済みの画像を再利用した場合、Integrityが正しく付与されないことがある
 
 WordPressの `get_attached_media()` は、`post_parent`（画像がどの投稿にアップロードされたか）が対象の投稿と一致する添付ファイルのみを返します。
 
 そのため、画像ブロックの「メディアライブラリ」タブから、既に他の投稿にアップロード済みの画像を選択して挿入した場合、その画像は `get_attached_media()` で取得されず、Integrityメタデータ（`_profile_attachment_integrity`）が生成されないことがあります。この場合、該当する画像は CA の署名対象（External Resource）に含まれません。
 
-**確認方法**: ログ出力を有効にすると、署名対象から除外された画像のURLが記録されます。
+また、画像をアップロードした時点でIntegrityメタデータの計算自体には成功していても、何らかの理由で値が壊れた状態（例: `integrity="sha256-"` のようにハッシュ部分が空）で保存されている場合、`get_attached_media()` で再取得・再検証されない限りその状態が残り続け、CA検証エラー（`ERR_CONTENT_ATTESTATION_SET_VERIFY_FAILED`）の原因になることがあります。
+
+**確認方法**: ログ出力を有効にすると、Integrityが欠落または不正な状態の画像のURLが記録されます。
 
 ```
-Post ID <投稿ID>, page <ページ番号>: image(s) missing integrity, excluded from signing (possibly not returned by get_attached_media()): <画像URL>, ...
+Post ID <投稿ID>, page <ページ番号>: image(s) with missing or invalid integrity (possibly not returned by get_attached_media(), or hash could not be computed): <画像URL>, ...
 ```
 
 **回避策**: 該当する画像をメディアライブラリから直接アップロードし直すことで、その投稿に添付され、Integrityメタデータが生成されます。

--- a/packages/wordpress/README.md
+++ b/packages/wordpress/README.md
@@ -399,6 +399,20 @@ Pro版では、画像がCDN経由で変換され、URLが変化する場合が�
 
 **回避策**： 一度記事を非公開にすることで、メタデータがクリアされます。その後再度公開することで UUID を指定しない新規登録となり、正常に登録されます。
 
+### 他の投稿に添付済みの画像を再利用した場合、Integrityが生成されないことがある
+
+WordPressの `get_attached_media()` は、`post_parent`（画像がどの投稿にアップロードされたか）が対象の投稿と一致する添付ファイルのみを返します。
+
+そのため、画像ブロックの「メディアライブラリ」タブから、既に他の投稿にアップロード済みの画像を選択して挿入した場合、その画像は `get_attached_media()` で取得されず、Integrityメタデータ（`_profile_attachment_integrity`）が生成されないことがあります。この場合、該当する画像は CA の署名対象（External Resource）に含まれません。
+
+**確認方法**: ログ出力を有効にすると、署名対象から除外された画像のURLが記録されます。
+
+```
+Post ID <投稿ID>, page <ページ番号>: image(s) missing integrity, excluded from signing (possibly not returned by get_attached_media()): <画像URL>, ...
+```
+
+**回避策**: 該当する画像をメディアライブラリから直接アップロードし直すことで、その投稿に添付され、Integrityメタデータが生成されます。
+
 ## 開発ガイド
 
 開発用 WordPress サーバーを利用して動作を確認できます。

--- a/packages/wordpress/includes/issue.php
+++ b/packages/wordpress/includes/issue.php
@@ -3,6 +3,9 @@
 
 namespace Profile\Issue;
 
+/** 画像ブロック(wp-block-image クラス)配下の img 要素を選択する XPath */
+const WP_BLOCK_IMAGE_XPATH = '//*[contains(@class, "wp-block-image")]//img';
+
 require_once __DIR__ . '/class-uca.php';
 use Profile\Uca\Uca;
 
@@ -298,7 +301,7 @@ function create_uca_list( \WP_Post $post, string $issuer_id, ?string $uuid = nul
 
 		$content            = \apply_filters( 'the_content', $content );
 		$html               = content_to_html( $content, \get_option( 'profile_ca_target_html', PROFILE_DEFAULT_CA_TARGET_HTML ), $title );
-		$external_resources = external_resources_from_html( $html, '//*[contains(@class, "wp-block-image")]//img[@integrity]' );
+		$external_resources = external_resources_from_html( $html, WP_BLOCK_IMAGE_XPATH . '[@integrity]' );
 
 		$images_without_integrity = find_images_without_integrity( $html );
 		if ( ! empty( $images_without_integrity ) ) {
@@ -409,12 +412,10 @@ function external_resources_from_html( string $html, string $xpath_query ): arra
  * @return array<string> Integrityが付与されていない、または壊れている画像のsrc一覧
  */
 function find_images_without_integrity( string $html ): array {
-	$xpath_query = '//*[contains(@class, "wp-block-image")]//img';
-
 	$document = new \DOMDocument();
 	$document->loadHTML( $html );
 	$xpath    = new \DOMXpath( $document );
-	$elements = $xpath->query( $xpath_query );
+	$elements = $xpath->query( WP_BLOCK_IMAGE_XPATH );
 
 	$images = array();
 
@@ -426,7 +427,7 @@ function find_images_without_integrity( string $html ): array {
 			}
 		}
 	} else {
-		debug( "No images found matching Xpath query: {$xpath_query}" );
+		debug( 'No images found matching Xpath query: ' . WP_BLOCK_IMAGE_XPATH );
 	}
 
 	return $images;

--- a/packages/wordpress/includes/issue.php
+++ b/packages/wordpress/includes/issue.php
@@ -409,17 +409,24 @@ function external_resources_from_html( string $html, string $xpath_query ): arra
  * @return array<string> Integrityが付与されていない、または壊れている画像のsrc一覧
  */
 function find_images_without_integrity( string $html ): array {
+	$xpath_query = '//*[contains(@class, "wp-block-image")]//img';
+
 	$document = new \DOMDocument();
 	$document->loadHTML( $html );
 	$xpath    = new \DOMXpath( $document );
-	$elements = $xpath->query( '//*[contains(@class, "wp-block-image")]//img' );
+	$elements = $xpath->query( $xpath_query );
 
 	$images = array();
-	foreach ( $elements as $element ) {
-		$integrity = $element->getAttribute( 'integrity' );
-		if ( '' === $integrity || preg_match( '/\bsha\d+-(?=\s|$)/', $integrity ) ) {
-			array_push( $images, $element->getAttribute( 'src' ) );
+
+	if ( $elements ) {
+		foreach ( $elements as $element ) {
+			$integrity = $element->getAttribute( 'integrity' );
+			if ( '' === $integrity || preg_match( '/\bsha\d+-(?=\s|$)/', $integrity ) ) {
+				array_push( $images, $element->getAttribute( 'src' ) );
+			}
 		}
+	} else {
+		debug( "No images found matching Xpath query: {$xpath_query}" );
 	}
 
 	return $images;

--- a/packages/wordpress/includes/issue.php
+++ b/packages/wordpress/includes/issue.php
@@ -300,6 +300,11 @@ function create_uca_list( \WP_Post $post, string $issuer_id, ?string $uuid = nul
 		$html               = content_to_html( $content, \get_option( 'profile_ca_target_html', PROFILE_DEFAULT_CA_TARGET_HTML ), $title );
 		$external_resources = external_resources_from_html( $html, '//*[contains(@class, "wp-block-image")]//img[@integrity]' );
 
+		$images_without_integrity = find_images_without_integrity( $html );
+		if ( ! empty( $images_without_integrity ) ) {
+			debug( "Post ID {$post->ID}, page {$page}: image(s) missing integrity, excluded from signing (possibly not returned by get_attached_media()): " . implode( ', ', $images_without_integrity ) );
+		}
+
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 
@@ -392,6 +397,29 @@ function external_resources_from_html( string $html, string $xpath_query ): arra
 	}
 
 	return $resources;
+}
+
+/**
+ * 署名対象HTMLの中で、Integrityが付与されていない画像のsrc一覧を取得
+ *
+ * 他の投稿に添付済みの画像を再利用した場合など、get_attached_media() で取得できない画像は
+ * Integrityメタデータが生成されないため、この一覧に含まれる。
+ *
+ * @param string $html HTML
+ * @return array<string> Integrityが付与されていない画像のsrc一覧
+ */
+function find_images_without_integrity( string $html ): array {
+	$document = new \DOMDocument();
+	$document->loadHTML( $html );
+	$xpath    = new \DOMXpath( $document );
+	$elements = $xpath->query( '//*[contains(@class, "wp-block-image")]//img[not(@integrity)]' );
+
+	$images = array();
+	foreach ( $elements as $element ) {
+		array_push( $images, $element->getAttribute( 'src' ) );
+	}
+
+	return $images;
 }
 
 /**
@@ -502,6 +530,7 @@ function request_ca( string $endpoint, string $admin_secret, string $method = 'P
 			$args['headers']['authorization'] = 'Basic ' . \sodium_bin2base64( $admin_secret, SODIUM_BASE64_VARIANT_ORIGINAL );
 			break;
 	}
+	debug( "Requesting CA server endpoint: {$endpoint} with method: {$method}" );
 	$res = \wp_remote_request( $endpoint, $args );
 	if ( \is_wp_error( $res ) ) {
 		$error_message = $res->get_error_message();

--- a/packages/wordpress/includes/issue.php
+++ b/packages/wordpress/includes/issue.php
@@ -302,7 +302,7 @@ function create_uca_list( \WP_Post $post, string $issuer_id, ?string $uuid = nul
 
 		$images_without_integrity = find_images_without_integrity( $html );
 		if ( ! empty( $images_without_integrity ) ) {
-			debug( "Post ID {$post->ID}, page {$page}: image(s) missing integrity, excluded from signing (possibly not returned by get_attached_media()): " . implode( ', ', $images_without_integrity ) );
+			debug( "Post ID {$post->ID}, page {$page}: image(s) with missing or invalid integrity (possibly not returned by get_attached_media(), or hash could not be computed): " . implode( ', ', $images_without_integrity ) );
 		}
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -400,23 +400,26 @@ function external_resources_from_html( string $html, string $xpath_query ): arra
 }
 
 /**
- * 署名対象HTMLの中で、Integrityが付与されていない画像のsrc一覧を取得
+ * 署名対象HTMLの中で、Integrityが付与されていない、または壊れている画像のsrc一覧を取得
  *
  * 他の投稿に添付済みの画像を再利用した場合など、get_attached_media() で取得できない画像は
- * Integrityメタデータが生成されないため、この一覧に含まれる。
+ * Integrityメタデータが生成されない、または壊れた値のまま残ることがあるため、この一覧に含まれる。
  *
  * @param string $html HTML
- * @return array<string> Integrityが付与されていない画像のsrc一覧
+ * @return array<string> Integrityが付与されていない、または壊れている画像のsrc一覧
  */
 function find_images_without_integrity( string $html ): array {
 	$document = new \DOMDocument();
 	$document->loadHTML( $html );
 	$xpath    = new \DOMXpath( $document );
-	$elements = $xpath->query( '//*[contains(@class, "wp-block-image")]//img[not(@integrity)]' );
+	$elements = $xpath->query( '//*[contains(@class, "wp-block-image")]//img' );
 
 	$images = array();
 	foreach ( $elements as $element ) {
-		array_push( $images, $element->getAttribute( 'src' ) );
+		$integrity = $element->getAttribute( 'integrity' );
+		if ( '' === $integrity || preg_match( '/\bsha\d+-(?=\s|$)/', $integrity ) ) {
+			array_push( $images, $element->getAttribute( 'src' ) );
+		}
 	}
 
 	return $images;

--- a/packages/wordpress/tests/issue.test.php
+++ b/packages/wordpress/tests/issue.test.php
@@ -96,4 +96,17 @@ EOD;
 
 		$this->assertSame( array(), find_images_without_integrity( $html ) );
 	}
+
+	public function test_find_images_without_integrity関数はハッシュ部分が空のintegrity値を検出する() {
+		$html = <<<'EOD'
+<div class="wp-block-post-content">
+<figure class="wp-block-image size-full"><img src="https://example.com/a.png" integrity="sha256-" /></figure>
+</div>
+EOD;
+
+		$this->assertSame(
+			array( 'https://example.com/a.png' ),
+			find_images_without_integrity( $html )
+		);
+	}
 }

--- a/packages/wordpress/tests/issue.test.php
+++ b/packages/wordpress/tests/issue.test.php
@@ -9,6 +9,7 @@ use const Profile\Config\PROFILE_DEFAULT_CA_TARGET_HTML;
 
 require_once __DIR__ . '/../includes/issue.php';
 use function Profile\Issue\content_to_html;
+use function Profile\Issue\find_images_without_integrity;
 
 final class Issue extends TestCase {
 	public function test_content_to_html_関数はHTMLを返す() {
@@ -65,5 +66,34 @@ EOD
 		$this->assertStringNotContainsString( '<h1', $text );
 		$this->assertStringNotContainsString( 'タイトル', $text );
 		$this->assertSame( '<body class="wp-block-post-content"><p>本文</p></body>', $text );
+	}
+
+	public function test_find_images_without_integrity関数はintegrity属性の無い画像のsrcを返す() {
+		$html = <<<'EOD'
+<div class="wp-block-post-content">
+<figure class="wp-block-image size-full"><img src="https://example.com/a.png" /></figure>
+</div>
+EOD;
+
+		$this->assertSame(
+			array( 'https://example.com/a.png' ),
+			find_images_without_integrity( $html )
+		);
+	}
+
+	public function test_find_images_without_integrity関数はintegrity属性のある画像を除外する() {
+		$html = <<<'EOD'
+<div class="wp-block-post-content">
+<figure class="wp-block-image size-full"><img src="https://example.com/a.png" integrity="sha256-xxx" /></figure>
+</div>
+EOD;
+
+		$this->assertSame( array(), find_images_without_integrity( $html ) );
+	}
+
+	public function test_find_images_without_integrity関数はwp_block_image外の画像を除外する() {
+		$html = '<img src="https://example.com/outside.png" />';
+
+		$this->assertSame( array(), find_images_without_integrity( $html ) );
 	}
 }


### PR DESCRIPTION
## 変更内容

- 画像のintegrity値が取得できないケースが発生した時にログを出力
- integrity値が取得できないケースに関してREADMEに追記

close #196

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

### 1. wordpressの起動

```
cd packages/wordpress 
docker compose up -d
```

### 2. CA Managerの無効

http://localhost:9000/wp-admin/plugins.php
このページを開いてCA ManagerのDeactivateボタンをクリック

### 3. 画像のアップロード

http://localhost:9000/wp-admin/upload.php
このページを開いて適当な画像をアップロードする
画像のアップロードが完了したらCA Managerを有効に戻す

### 4. 記事に画像を添付

工程3でアップロードした画像を何かしら他の記事に添付して投稿を行う

### 5. ログにintegrityがない画像に関して出力されているか確認

http://localhost:9000/wp-admin/options-general.php?page=ca-manager
ここからログをDLして
Post ID 7, page 1: image(s) with missing or invalid integrity (possibly not returned by get_attached_media(), or hash could not be computed): http://localhost:9000/wp-content/uploads/2026/08/Screenshot-from-2026-03-03-09-42-01.png
このようにintegrityの取得に失敗した画像が取得できるか