### PR TITLE
feat: signJwtVc の鍵引数を Jwk | JwtSigner に拡張

### DIFF
--- a/packages/opvc/src/content-attestation.ts
+++ b/packages/opvc/src/content-attestation.ts
@@ -1,14 +1,14 @@
 import { UnsignedContentAttestation } from "@originator-profile/model";
+import type {
+  JwtSigner,
+  KeyMaterial,
+} from "@originator-profile/securing-mechanism";
 import {
   fetchAndSetDigestSri,
   fetchAndSetTargetIntegrity,
   signCa,
   type DocumentProvider,
 } from "@originator-profile/sign";
-import type {
-  JwtSigner,
-  KeyMaterial,
-} from "@originator-profile/securing-mechanism";
 import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import type { HashAlgorithm } from "websri";

--- a/packages/opvc/src/content-attestation.ts
+++ b/packages/opvc/src/content-attestation.ts
@@ -1,13 +1,14 @@
-import {
-  UnsignedContentAttestation,
-  type Jwk,
-} from "@originator-profile/model";
+import { UnsignedContentAttestation } from "@originator-profile/model";
 import {
   fetchAndSetDigestSri,
   fetchAndSetTargetIntegrity,
   signCa,
   type DocumentProvider,
 } from "@originator-profile/sign";
+import type {
+  JwtSigner,
+  KeyMaterial,
+} from "@originator-profile/securing-mechanism";
 import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import type { HashAlgorithm } from "websri";
@@ -67,19 +68,19 @@ export async function unsignedCa(
 /**
  * Content Attestation への署名
  * @param uca 未署名 Content Attestation オブジェクト
- * @param privateKey プライベート鍵
+ * @param signer プライベート鍵、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @throws {BadRequestError} 入力が UnsignedContentAttestation スキーマに適合しない場合/検証対象のコンテンツが存在しない/コンテンツにアクセスできない/Integrityの計算に失敗
  * @return Content Attestation
  */
 export async function sign(
   uca: UnsignedContentAttestation,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   options: TimingOptions = {},
 ): Promise<string> {
   const { issuedAt, expiredAt } = parseDates(options);
   const payload = await unsignedCa(uca, { issuedAt, expiredAt });
 
-  return await signCa(payload, privateKey, {
+  return await signCa(payload, signer, {
     issuedAt,
     expiredAt,
     documentProvider: defaultDocumentProvider,

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -1,5 +1,4 @@
 import {
-  type Jwk,
   UnsignedWebsiteProfile,
   UnsignedWebsiteProfileSet,
 } from "@originator-profile/model";
@@ -8,6 +7,10 @@ import {
   signWsp,
   UnsignedWebsiteProfileInput,
 } from "@originator-profile/sign";
+import type {
+  JwtSigner,
+  KeyMaterial,
+} from "@originator-profile/securing-mechanism";
 import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import { parseDates, type TimingOptions } from "./timing-options.ts";
@@ -61,18 +64,18 @@ export async function unsignedWsp<U extends UnsignedWebsiteProfileInput>(
  * 配列を渡した場合、各要素を個別に署名して JWT 文字列の配列を返します。
  *
  * @param uwsp 未署名 Website Profile (単一または配列)
- * @param privateKey プライベート鍵
+ * @param signer プライベート鍵、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @throws {BadRequestError} 配列入力の整合性違反や入力が UnsignedWebsiteProfile スキーマに適合しない場合
  * @return 単一入力時は JWT 文字列、配列入力時は JWT 文字列の配列
  */
 export async function sign<U extends UnsignedWebsiteProfileInput>(
   uwsp: U,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   options: TimingOptions = {},
 ): Promise<U extends unknown[] ? string[] : string> {
   const timing = parseDates(options);
   try {
-    return await signWsp(uwsp, privateKey, timing);
+    return await signWsp(uwsp, signer, timing);
   } catch (e) {
     throw new BadRequestError((e as Error).message, { cause: e });
   }

--- a/packages/opvc/src/website-profile.ts
+++ b/packages/opvc/src/website-profile.ts
@@ -2,15 +2,15 @@ import {
   UnsignedWebsiteProfile,
   UnsignedWebsiteProfileSet,
 } from "@originator-profile/model";
+import type {
+  JwtSigner,
+  KeyMaterial,
+} from "@originator-profile/securing-mechanism";
 import {
   fetchAndSetDigestSri,
   signWsp,
   UnsignedWebsiteProfileInput,
 } from "@originator-profile/sign";
-import type {
-  JwtSigner,
-  KeyMaterial,
-} from "@originator-profile/securing-mechanism";
 import { getUnixTime } from "date-fns";
 import { BadRequestError } from "http-errors-enhanced";
 import { parseDates, type TimingOptions } from "./timing-options.ts";

--- a/packages/securing-mechanism/src/jwt/index.ts
+++ b/packages/securing-mechanism/src/jwt/index.ts
@@ -1,5 +1,6 @@
 export * from "./decode-vc";
 export * from "./map-vc";
 export * from "./sign-vc";
+export * from "./signer";
 export * from "./types";
 export * from "./verify-vc";

--- a/packages/securing-mechanism/src/jwt/sign-vc.test.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@originator-profile/model";
 import { addYears, getUnixTime } from "date-fns";
 import { decodeJwt, decodeProtectedHeader, exportJWK, jwtVerify } from "jose";
+import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, test } from "vitest";
 import { signJwtVc } from "./sign-vc";
 import type { JwtSigner } from "./signer";
@@ -321,6 +322,27 @@ describe("signer", () => {
       true,
       ["sign", "verify"],
     );
+    const expectedKid = await createThumbprint(await exportJWK(publicKey));
+
+    const jwt = await signJwtVc(wsp, privateKey, { issuedAt, expiredAt });
+    expect(decodeProtectedHeader(jwt).kid).toBe(expectedKid);
+
+    const { payload } = await jwtVerify(jwt, publicKey);
+    expect(payload).toStrictEqual({
+      iss: wsp.issuer,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+      sub: wsp.credentialSubject.id,
+      ...wsp,
+    });
+  });
+
+  test("KeyObject (Node) の場合、公開鍵の thumbprint から kid を自動導出する", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+    });
     const expectedKid = await createThumbprint(await exportJWK(publicKey));
 
     const jwt = await signJwtVc(wsp, privateKey, { issuedAt, expiredAt });

--- a/packages/securing-mechanism/src/jwt/sign-vc.test.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.test.ts
@@ -408,6 +408,37 @@ describe("signer", () => {
     });
   });
 
+  test("JwtSigner を渡しても options.kid を指定すれば優先される", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    const signer: JwtSigner = {
+      alg: "ES256",
+      kid: "kms-key-1",
+      sign: async (signingInput) =>
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: "ECDSA", hash: "SHA-256" },
+            privateKey,
+            signingInput as BufferSource,
+          ),
+        ),
+    };
+
+    const jwt = await signJwtVc(wsp, signer, {
+      issuedAt,
+      expiredAt,
+      kid: "override-kid",
+    });
+    expect(decodeProtectedHeader(jwt).kid).toBe("override-kid");
+    await expect(jwtVerify(jwt, publicKey)).resolves.toBeDefined();
+  });
+
   test("JwtSigner の alg と options.alg が矛盾するとエラーになる", async () => {
     const issuedAt = new Date();
     const expiredAt = addYears(new Date(), 10);
@@ -420,5 +451,35 @@ describe("signer", () => {
     await expect(
       signJwtVc(wsp, signer, { issuedAt, expiredAt, alg: "RS256" }),
     ).rejects.toThrow(/alg/);
+  });
+
+  test("JwtSigner の alg と options.alg が一致していればエラーにならない", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    const signer: JwtSigner = {
+      alg: "ES256",
+      kid: "kms-key-1",
+      sign: async (signingInput) =>
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: "ECDSA", hash: "SHA-256" },
+            privateKey,
+            signingInput as BufferSource,
+          ),
+        ),
+    };
+
+    const jwt = await signJwtVc(wsp, signer, {
+      issuedAt,
+      expiredAt,
+      alg: "ES256",
+    });
+    await expect(jwtVerify(jwt, publicKey)).resolves.toBeDefined();
   });
 });

--- a/packages/securing-mechanism/src/jwt/sign-vc.test.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.test.ts
@@ -1,4 +1,4 @@
-import { generateKey } from "@originator-profile/cryptography";
+import { createThumbprint, generateKey } from "@originator-profile/cryptography";
 import {
   AdvertisementCA,
   AdvertorialCA,
@@ -7,9 +7,10 @@ import {
   WebsiteProfile,
 } from "@originator-profile/model";
 import { addYears, getUnixTime } from "date-fns";
-import { decodeJwt, decodeProtectedHeader } from "jose";
+import { decodeJwt, decodeProtectedHeader, exportJWK, jwtVerify } from "jose";
 import { describe, expect, test } from "vitest";
 import { signJwtVc } from "./sign-vc";
+import type { JwtSigner } from "./signer";
 
 test("signJwtVc() returns valid Website Profile", async () => {
   const issuedAt = new Date();
@@ -283,5 +284,138 @@ describe("CA", () => {
       sub: ca.credentialSubject.id,
       ...ca,
     });
+  });
+});
+
+describe("signer", () => {
+  const wsp: WebsiteProfile = {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://originator-profile.org/ns/credentials/v1",
+      "https://originator-profile.org/ns/cip/v1",
+      { "@language": "ja" },
+    ],
+    type: ["VerifiableCredential", "WebsiteProfile"],
+    issuer: "dns:example.com",
+    credentialSubject: {
+      id: "https://media.example.com/",
+      type: "WebSite",
+      name: "<Webサイトのタイトル>",
+      description: "<Webサイトの説明>",
+      image: {
+        id: "https://media.example.com/image.png",
+        digestSRI: "sha256-Upwn7gYMuRmJlD1ZivHk876vXHzokXrwXj50VgfnMnY=",
+      },
+      allowedOrigin: ["https://media.example.com"],
+    },
+  };
+
+  test("extractable な CryptoKey の場合、公開鍵の thumbprint から kid を自動導出する", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      true,
+      ["sign", "verify"],
+    );
+    const expectedKid = await createThumbprint(await exportJWK(publicKey));
+
+    const jwt = await signJwtVc(wsp, privateKey, { issuedAt, expiredAt });
+    expect(decodeProtectedHeader(jwt).kid).toBe(expectedKid);
+
+    const { payload } = await jwtVerify(jwt, publicKey);
+    expect(payload).toStrictEqual({
+      iss: wsp.issuer,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+      sub: wsp.credentialSubject.id,
+      ...wsp,
+    });
+  });
+
+  test("non-extractable な CryptoKey で kid 未指定の場合はエラーになる", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    await expect(
+      signJwtVc(wsp, privateKey, { issuedAt, expiredAt }),
+    ).rejects.toThrow(/kid/);
+  });
+
+  test("non-extractable な CryptoKey でも options.kid を指定すれば署名できる", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    const jwt = await signJwtVc(wsp, privateKey, {
+      issuedAt,
+      expiredAt,
+      kid: "hsm-key-1",
+    });
+    expect(decodeProtectedHeader(jwt).kid).toBe("hsm-key-1");
+    await expect(jwtVerify(jwt, publicKey)).resolves.toBeDefined();
+  });
+
+  test("JwtSigner を渡すと Compact JWS を手組みし、jose で検証可能な JWT を返す", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const { privateKey, publicKey } = await crypto.subtle.generateKey(
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["sign", "verify"],
+    );
+
+    const signer: JwtSigner = {
+      alg: "ES256",
+      kid: "kms-key-1",
+      sign: async (signingInput) =>
+        new Uint8Array(
+          await crypto.subtle.sign(
+            { name: "ECDSA", hash: "SHA-256" },
+            privateKey,
+            signingInput as BufferSource,
+          ),
+        ),
+    };
+
+    const jwt = await signJwtVc(wsp, signer, { issuedAt, expiredAt });
+    expect(decodeProtectedHeader(jwt)).toStrictEqual({
+      alg: "ES256",
+      kid: "kms-key-1",
+      typ: "vc+jwt",
+      cty: "vc",
+    });
+
+    const { payload } = await jwtVerify(jwt, publicKey);
+    expect(payload).toStrictEqual({
+      iss: wsp.issuer,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+      sub: wsp.credentialSubject.id,
+      ...wsp,
+    });
+  });
+
+  test("JwtSigner の alg と options.alg が矛盾するとエラーになる", async () => {
+    const issuedAt = new Date();
+    const expiredAt = addYears(new Date(), 10);
+    const signer: JwtSigner = {
+      alg: "ES256",
+      kid: "kms-key-1",
+      sign: async () => new Uint8Array(),
+    };
+
+    await expect(
+      signJwtVc(wsp, signer, { issuedAt, expiredAt, alg: "RS256" }),
+    ).rejects.toThrow(/alg/);
   });
 });

--- a/packages/securing-mechanism/src/jwt/sign-vc.test.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.test.ts
@@ -1,4 +1,7 @@
-import { createThumbprint, generateKey } from "@originator-profile/cryptography";
+import {
+  createThumbprint,
+  generateKey,
+} from "@originator-profile/cryptography";
 import {
   AdvertisementCA,
   AdvertorialCA,

--- a/packages/securing-mechanism/src/jwt/sign-vc.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.ts
@@ -13,19 +13,17 @@ function isJwk(keyMaterial: KeyMaterial): keyMaterial is Jwk {
   return "kty" in keyMaterial;
 }
 
-async function resolveKid(
-  keyMaterial: KeyMaterial,
-  alg: string,
-): Promise<string> {
+async function resolveKid(keyMaterial: KeyMaterial): Promise<string> {
   if (isJwk(keyMaterial)) {
-    return keyMaterial.kid ?? (await createThumbprint(keyMaterial, alg));
+    return keyMaterial.kid ?? (await createThumbprint(keyMaterial));
   }
   try {
     const jwk = await exportJWK(keyMaterial);
-    return await createThumbprint(jwk, alg);
-  } catch {
+    return await createThumbprint(jwk);
+  } catch (e) {
     throw new Error(
       "Could not derive kid from the key (it may be non-extractable). Specify options.kid explicitly.",
+      { cause: e },
     );
   }
 }
@@ -43,7 +41,7 @@ async function resolveAlgAndKid(
     return { alg: signer.alg, kid: options.kid ?? signer.kid };
   }
   const alg = options.alg ?? "ES256";
-  return { alg, kid: options.kid ?? (await resolveKid(signer, alg)) };
+  return { alg, kid: options.kid ?? (await resolveKid(signer)) };
 }
 
 /**

--- a/packages/securing-mechanism/src/jwt/sign-vc.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.ts
@@ -62,14 +62,13 @@ export async function signJwtVc<T extends SignableVc>(
     expiredAt: Date;
   },
 ): Promise<string> {
-  const payload = vc;
   const { issuedAt, expiredAt } = options;
   const { alg, kid } = await resolveAlgAndKid(signer, options);
   const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
 
   if (isJwtSigner(signer)) {
     const claims = {
-      ...payload,
+      ...vc,
       iss: vc.issuer,
       sub: vc.credentialSubject.id,
       iat: getUnixTime(issuedAt),
@@ -85,7 +84,7 @@ export async function signJwtVc<T extends SignableVc>(
   }
 
   const key = isJwk(signer) ? await importJWK(signer, alg) : signer;
-  return await new SignJWT(payload)
+  return await new SignJWT(vc)
     .setProtectedHeader(header)
     .setIssuer(vc.issuer)
     .setSubject(vc.credentialSubject.id)

--- a/packages/securing-mechanism/src/jwt/sign-vc.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.ts
@@ -30,6 +30,22 @@ async function resolveKid(
   }
 }
 
+async function resolveAlgAndKid(
+  signer: KeyMaterial | JwtSigner,
+  options: { alg?: string; kid?: string },
+): Promise<{ alg: string; kid: string }> {
+  if (isJwtSigner(signer)) {
+    if (options.alg !== undefined && options.alg !== signer.alg) {
+      throw new Error(
+        `options.alg ("${options.alg}") は signer.alg ("${signer.alg}") と一致している必要があります。`,
+      );
+    }
+    return { alg: signer.alg, kid: options.kid ?? signer.kid };
+  }
+  const alg = options.alg ?? "ES256";
+  return { alg, kid: options.kid ?? (await resolveKid(signer, alg)) };
+}
+
 /**
  * VC への署名
  * @param vc VC オブジェクト
@@ -48,16 +64,10 @@ export async function signJwtVc<T extends SignableVc>(
 ): Promise<string> {
   const payload = vc;
   const { issuedAt, expiredAt } = options;
+  const { alg, kid } = await resolveAlgAndKid(signer, options);
+  const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
 
   if (isJwtSigner(signer)) {
-    if (options.alg !== undefined && options.alg !== signer.alg) {
-      throw new Error(
-        `options.alg ("${options.alg}") は signer.alg ("${signer.alg}") と一致している必要があります。`,
-      );
-    }
-    const alg = signer.alg;
-    const kid = options.kid ?? signer.kid;
-    const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
     const claims = {
       ...payload,
       iss: vc.issuer,
@@ -74,17 +84,12 @@ export async function signJwtVc<T extends SignableVc>(
     return `${encodedHeader}.${encodedPayload}.${base64url.encode(signature)}`;
   }
 
-  const { alg = "ES256" } = options;
-  const kid = options.kid ?? (await resolveKid(signer, alg));
-  const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
   const key = isJwk(signer) ? await importJWK(signer, alg) : signer;
-
-  const jwt = await new SignJWT(payload)
+  return await new SignJWT(payload)
     .setProtectedHeader(header)
     .setIssuer(vc.issuer)
     .setSubject(vc.credentialSubject.id)
     .setIssuedAt(getUnixTime(issuedAt))
     .setExpirationTime(getUnixTime(expiredAt))
     .sign(key);
-  return jwt;
 }

--- a/packages/securing-mechanism/src/jwt/sign-vc.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.ts
@@ -1,44 +1,90 @@
 import { createThumbprint } from "@originator-profile/cryptography";
-import { Jwk } from "@originator-profile/model";
+import type { Jwk } from "@originator-profile/model";
 import { getUnixTime } from "date-fns";
-import { importJWK, SignJWT } from "jose";
+import { base64url, exportJWK, importJWK, SignJWT } from "jose";
+import { isJwtSigner, type JwtSigner, type KeyMaterial } from "./signer";
 
 type SignableVc = {
   issuer: string;
   credentialSubject: { id: string };
 };
 
+function isJwk(keyMaterial: KeyMaterial): keyMaterial is Jwk {
+  return "kty" in keyMaterial;
+}
+
+async function resolveKid(
+  keyMaterial: KeyMaterial,
+  alg: string,
+): Promise<string> {
+  if (isJwk(keyMaterial)) {
+    return keyMaterial.kid ?? (await createThumbprint(keyMaterial, alg));
+  }
+  try {
+    const jwk = await exportJWK(keyMaterial);
+    return await createThumbprint(jwk, alg);
+  } catch {
+    throw new Error(
+      "kid を鍵から自動導出できませんでした (non-extractable な鍵の可能性があります)。options.kid を明示的に指定してください。",
+    );
+  }
+}
+
 /**
  * VC への署名
  * @param vc VC オブジェクト
- * @param privateKey プライベートキー
+ * @param signer プライベートキー (Jwk/CryptoKey/KeyObject)、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @return JWT でエンコードされた VC
  */
 export async function signJwtVc<T extends SignableVc>(
   vc: T,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   options: {
     alg?: string;
+    kid?: string;
     issuedAt: Date;
     expiredAt: Date;
   },
 ): Promise<string> {
   const payload = vc;
-  const { alg = "ES256", issuedAt, expiredAt } = options;
-  const header = {
-    alg,
-    kid: privateKey.kid ?? (await createThumbprint(privateKey, alg)),
-    typ: "vc+jwt",
-    cty: "vc",
-  };
+  const { issuedAt, expiredAt } = options;
 
-  const privateKeyImported = await importJWK(privateKey, alg);
+  if (isJwtSigner(signer)) {
+    if (options.alg !== undefined && options.alg !== signer.alg) {
+      throw new Error(
+        `options.alg ("${options.alg}") は signer.alg ("${signer.alg}") と一致している必要があります。`,
+      );
+    }
+    const alg = signer.alg;
+    const kid = options.kid ?? signer.kid;
+    const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
+    const claims = {
+      ...payload,
+      iss: vc.issuer,
+      sub: vc.credentialSubject.id,
+      iat: getUnixTime(issuedAt),
+      exp: getUnixTime(expiredAt),
+    };
+    const encodedHeader = base64url.encode(JSON.stringify(header));
+    const encodedPayload = base64url.encode(JSON.stringify(claims));
+    const signingInput = new TextEncoder().encode(
+      `${encodedHeader}.${encodedPayload}`,
+    );
+    const signature = await signer.sign(signingInput);
+    return `${encodedHeader}.${encodedPayload}.${base64url.encode(signature)}`;
+  }
+
+  const { alg = "ES256" } = options;
+  const kid = options.kid ?? (await resolveKid(signer, alg));
+  const header = { alg, kid, typ: "vc+jwt", cty: "vc" };
+  const key = isJwk(signer) ? await importJWK(signer, alg) : signer;
+
   const jwt = await new SignJWT(payload)
     .setProtectedHeader(header)
     .setIssuer(vc.issuer)
     .setSubject(vc.credentialSubject.id)
     .setIssuedAt(getUnixTime(issuedAt))
     .setExpirationTime(getUnixTime(expiredAt))
-    .sign(privateKeyImported);
+    .sign(key);
   return jwt;
 }

--- a/packages/securing-mechanism/src/jwt/sign-vc.ts
+++ b/packages/securing-mechanism/src/jwt/sign-vc.ts
@@ -25,7 +25,7 @@ async function resolveKid(
     return await createThumbprint(jwk, alg);
   } catch {
     throw new Error(
-      "kid を鍵から自動導出できませんでした (non-extractable な鍵の可能性があります)。options.kid を明示的に指定してください。",
+      "Could not derive kid from the key (it may be non-extractable). Specify options.kid explicitly.",
     );
   }
 }
@@ -37,7 +37,7 @@ async function resolveAlgAndKid(
   if (isJwtSigner(signer)) {
     if (options.alg !== undefined && options.alg !== signer.alg) {
       throw new Error(
-        `options.alg ("${options.alg}") は signer.alg ("${signer.alg}") と一致している必要があります。`,
+        `options.alg ("${options.alg}") must match signer.alg ("${signer.alg}").`,
       );
     }
     return { alg: signer.alg, kid: options.kid ?? signer.kid };

--- a/packages/securing-mechanism/src/jwt/signer.ts
+++ b/packages/securing-mechanism/src/jwt/signer.ts
@@ -1,5 +1,5 @@
-import type { CryptoKey, KeyObject } from "jose";
 import type { Jwk } from "@originator-profile/model";
+import type { CryptoKey, KeyObject } from "jose";
 
 /**
  * 鍵材料を外部に渡さない不透明な署名者
@@ -23,6 +23,8 @@ export type JwtSigner = {
 export type KeyMaterial = Jwk | CryptoKey | KeyObject;
 
 /** signer が JwtSigner (不透明な署名者) かどうかを判定する */
-export function isJwtSigner(signer: KeyMaterial | JwtSigner): signer is JwtSigner {
+export function isJwtSigner(
+  signer: KeyMaterial | JwtSigner,
+): signer is JwtSigner {
   return "sign" in signer && typeof signer.sign === "function";
 }

--- a/packages/securing-mechanism/src/jwt/signer.ts
+++ b/packages/securing-mechanism/src/jwt/signer.ts
@@ -26,5 +26,7 @@ export type KeyMaterial = Jwk | CryptoKey | KeyObject;
 export function isJwtSigner(
   signer: KeyMaterial | JwtSigner,
 ): signer is JwtSigner {
-  return "sign" in signer && typeof signer.sign === "function";
+  return (
+    !("kty" in signer) && "sign" in signer && typeof signer.sign === "function"
+  );
 }

--- a/packages/securing-mechanism/src/jwt/signer.ts
+++ b/packages/securing-mechanism/src/jwt/signer.ts
@@ -1,0 +1,28 @@
+import type { CryptoKey, KeyObject } from "jose";
+import type { Jwk } from "@originator-profile/model";
+
+/**
+ * 鍵材料を外部に渡さない不透明な署名者
+ *
+ * HSM・セキュアエレメント・クラウドKMS(AWS KMS, Google Cloud KMS, Azure Key Vault等)・
+ * WebAuthn/FIDO2など、秘密鍵をハードウェア境界外に取り出せない署名環境向けの注入口。
+ */
+export type JwtSigner = {
+  /** JWS alg */
+  alg: string;
+  /** JWS kid (鍵材料を持たないためサムプリントによるフォールバック計算ができない) */
+  kid: string;
+  /**
+   * signingInput (base64url(header) + "." + base64url(payload) の ASCII バイト列) に対する
+   * 生の署名バイト列 (JOSE 形式。例えば ES256 なら r||s の固定長結合) を返す。
+   */
+  sign: (signingInput: Uint8Array) => Promise<Uint8Array>;
+};
+
+/** ソフトウェア鍵として直接扱える鍵材料 */
+export type KeyMaterial = Jwk | CryptoKey | KeyObject;
+
+/** signer が JwtSigner (不透明な署名者) かどうかを判定する */
+export function isJwtSigner(signer: KeyMaterial | JwtSigner): signer is JwtSigner {
+  return "sign" in signer && typeof signer.sign === "function";
+}

--- a/packages/sign/src/sign-ca.ts
+++ b/packages/sign/src/sign-ca.ts
@@ -1,8 +1,9 @@
-import type {
-  Jwk,
-  UnsignedContentAttestation,
-} from "@originator-profile/model";
-import { signJwtVc } from "@originator-profile/securing-mechanism";
+import type { UnsignedContentAttestation } from "@originator-profile/model";
+import {
+  type JwtSigner,
+  type KeyMaterial,
+  signJwtVc,
+} from "@originator-profile/securing-mechanism";
 import type { HashAlgorithm } from "websri";
 import {
   type DocumentProvider,
@@ -13,20 +14,22 @@ import {
 /**
  * Content Attestation への署名
  * @param uca 未署名 Content Attestation オブジェクト
- * @param privateKey プライベート鍵
+ * @param signer プライベート鍵、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @return JWT でエンコードされた Content Attestation
  */
 export async function signCa(
   uca: UnsignedContentAttestation,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   {
-    alg = "ES256",
+    alg,
+    kid,
     issuedAt = new Date(),
     expiredAt,
     integrityAlg = "sha256",
     documentProvider = async () => document,
   }: {
     alg?: string;
+    kid?: string;
     issuedAt?: Date;
     expiredAt: Date;
     integrityAlg?: HashAlgorithm;
@@ -45,7 +48,7 @@ export async function signCa(
 
   return await signJwtVc(
     { ...uca, credentialSubject: { ...uca.credentialSubject, id } },
-    privateKey,
-    { alg, issuedAt, expiredAt },
+    signer,
+    { alg, kid, issuedAt, expiredAt },
   );
 }

--- a/packages/sign/src/sign-cp.ts
+++ b/packages/sign/src/sign-cp.ts
@@ -1,20 +1,25 @@
-import { CoreProfile, Jwk } from "@originator-profile/model";
-import { signJwtVc } from "@originator-profile/securing-mechanism";
+import { CoreProfile } from "@originator-profile/model";
+import {
+  type JwtSigner,
+  type KeyMaterial,
+  signJwtVc,
+} from "@originator-profile/securing-mechanism";
 
 /**
  * CP への署名
  * @param cp CoreProfile オブジェクト
- * @param privateKey プライベート鍵
+ * @param signer プライベート鍵、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @return JWT でエンコードされた CP
  */
 export async function signCp(
   cp: CoreProfile,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   options: {
     alg?: string;
+    kid?: string;
     issuedAt: Date;
     expiredAt: Date;
   },
 ): Promise<string> {
-  return signJwtVc(cp, privateKey, options);
+  return signJwtVc(cp, signer, options);
 }

--- a/packages/sign/src/sign-wsp.ts
+++ b/packages/sign/src/sign-wsp.ts
@@ -1,15 +1,19 @@
 import {
-  type Jwk,
   UnsignedWebsiteProfile,
   UnsignedWebsiteProfileSet,
 } from "@originator-profile/model";
-import { signJwtVc } from "@originator-profile/securing-mechanism";
+import {
+  type JwtSigner,
+  type KeyMaterial,
+  signJwtVc,
+} from "@originator-profile/securing-mechanism";
 import type { HashAlgorithm } from "websri";
 import { z } from "zod";
 import { fetchAndSetDigestSri } from "./integrity/";
 
 type SignWspOptions = {
   alg?: string;
+  kid?: string;
   issuedAt?: Date;
   expiredAt: Date;
   integrityAlg?: HashAlgorithm;
@@ -30,7 +34,7 @@ export type UnsignedWebsiteProfileInput = z.infer<
  * 配列を渡した場合、各要素を個別に署名して JWT 文字列の配列を返します。
  *
  * @param uwsp 未署名 Website Profile オブジェクト (単一または配列)
- * @param privateKey プライベート鍵
+ * @param signer プライベート鍵、または HSM・KMS・WebAuthn等の外部署名者 (JwtSigner)
  * @return JWT でエンコードされた Website Profile (配列入力時は配列)
  * @throws {Error} UnsignedWebsiteProfile(Set) スキーマに適合しない場合
  */
@@ -38,9 +42,10 @@ export async function signWsp<
   U extends UnsignedWebsiteProfile | UnsignedWebsiteProfileSet,
 >(
   uwsp: U,
-  privateKey: Jwk,
+  signer: KeyMaterial | JwtSigner,
   {
-    alg = "ES256",
+    alg,
+    kid,
     issuedAt = new Date(),
     expiredAt,
     integrityAlg = "sha256",
@@ -50,7 +55,7 @@ export async function signWsp<
   UnsignedWebsiteProfileInput.parse(uwsp);
   async function sign(item: UnsignedWebsiteProfile): Promise<string> {
     await fetchAndSetDigestSri(integrityAlg, item.credentialSubject.image);
-    return await signJwtVc(item, privateKey, { alg, issuedAt, expiredAt });
+    return await signJwtVc(item, signer, { alg, kid, issuedAt, expiredAt });
   }
   if (Array.isArray(uwsp)) {
     const wsps = await Promise.all(uwsp.map(sign));


### PR DESCRIPTION
## 変更内容

`signJwtVc` の鍵引数を `Jwk` から `KeyMaterial (Jwk | CryptoKey | KeyObject) | JwtSigner` のユニオンに拡張した。`JwtSigner` は秘密鍵材料を外部に一切出さない不透明な署名者インターフェースで、HSM・セキュアエレメント・クラウドKMS(AWS KMS, Google Cloud KMS, Azure Key Vault等)・WebAuthn/FIDO2 など、鍵をハードウェア境界外に取り出せない署名環境向けの注入口として設計した。

### 設計方針

- 鍵材料系 (`Jwk`/`CryptoKey`/`KeyObject`) は既存の jose (`SignJWT`) 実装にそのまま委譲する。jose が保証している spec 準拠の署名処理・鍵整合性検証を手放さないため。
- `JwtSigner` (opaque な署名者) のみ Compact JWS を手組みする (jose の `base64url` ユーティリティを再利用)。jose 自体がカスタム非同期署名関数の注入口を持たないため、この経路だけは避けられない。
  - RFC 7515 は JWS Payload/Protected Header の JSON シリアライズにキー順序の正規化を要求しておらず、jose 自身の実装(`JSON.stringify` をそのまま使用)とも整合していることを確認済み。
  - テストでは実際に `crypto.subtle.sign` で署名した `JwtSigner` を jose 本物の `jwtVerify()` で検証まで通し、手組みしたCompact JWSがspec準拠であることを実証している。
- kid は `options.kid` による明示指定を最優先し、なければベストエフォートで JWK thumbprint から自動導出、non-extractable な鍵で導出不能な場合は明示的にエラーにする。
- alg は `JwtSigner` 使用時は `signer.alg` が正、`options.alg` と矛盾する場合は throw する。

`packages/sign` の `signWsp`/`signCp`/`signCa` も同様に signer 引数を拡張し、KMS 等の外部署名者を上位レイヤーからも注入できるようにした。`opvc` CLI 側の対応は今回のスコープ外(型の後方互換性は保たれているため既存呼び出しはそのまま動作する)。

close #453

## 確認手順

- 追加されたテストコードの妥当性の確認:
  - `packages/securing-mechanism`: `pnpm lint` (oxlint typeCheck 込み) / `pnpm test` で 13 件のテストが通ることを確認 (extractable/non-extractable CryptoKey、`options.kid` 上書き、`JwtSigner` 経由の署名とjoseによる検証、alg不整合時のエラー等)
  - `packages/sign`: `pnpm lint` / `pnpm test` で既存 44 件のテストが引き続き通ることを確認 (signJwtVc の呼び出し元が非破壊的に拡張されていることの確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)