### PR TITLE
CA だけで SP がない場合の表示の追加

### DIFF
--- a/apps/inspector/e2e/cas.test.ts
+++ b/apps/inspector/e2e/cas.test.ts
@@ -30,6 +30,7 @@ test("Content Attestation Set の表示が正常に行えたか", async ({
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("cas")).toBeVisible();
+  await expect(ext?.getByTestId("site-profile-missing")).toBeVisible();
 
   await gotoDetailPage(ext);
   await expectStatus(ext, "content-attestation-set", "check");

--- a/apps/inspector/public/_locales/en/messages.json
+++ b/apps/inspector/public/_locales/en/messages.json
@@ -515,7 +515,7 @@
   "SiteProfile_Missing": {
     "message": "Site Profile not found"
   },
-  "SiteProfile_Missing_Detail": {
+  "SiteProfile_Missing_Reason": {
     "message": "It is possible that the site profile could not be retrieved. This does not indicate any issues regarding the site's safety."
   }
 }

--- a/apps/inspector/public/_locales/en/messages.json
+++ b/apps/inspector/public/_locales/en/messages.json
@@ -511,5 +511,11 @@
   },
   "GlobalHeader_Reload": {
     "message": "Reload"
+  },
+  "SiteProfile_Missing": {
+    "message": "Site Profile not found"
+  },
+  "SiteProfile_Missing_Detail": {
+    "message": "It is possible that the site profile could not be retrieved. This does not indicate any issues regarding the site's safety."
   }
 }

--- a/apps/inspector/public/_locales/ja/messages.json
+++ b/apps/inspector/public/_locales/ja/messages.json
@@ -511,5 +511,11 @@
   },
   "GlobalHeader_Reload": {
     "message": "再読み込み"
+  },
+  "SiteProfile_Missing": {
+    "message": "サイトプロファイルが見つかりませんでした"
+  },
+  "SiteProfile_Missing_Detail": {
+    "message": "サイトプロファイルを取得できなかった可能性があります。サイトの安全性を否定するものではありません。"
   }
 }

--- a/apps/inspector/public/_locales/ja/messages.json
+++ b/apps/inspector/public/_locales/ja/messages.json
@@ -515,7 +515,7 @@
   "SiteProfile_Missing": {
     "message": "サイトプロファイルが見つかりませんでした"
   },
-  "SiteProfile_Missing_Detail": {
+  "SiteProfile_Missing_Reason": {
     "message": "サイトプロファイルを取得できなかった可能性があります。サイトの安全性を否定するものではありません。"
   }
 }

--- a/apps/inspector/src/pages/SiteProfile.tsx
+++ b/apps/inspector/src/pages/SiteProfile.tsx
@@ -1,4 +1,5 @@
 import { selectByLocale } from "@originator-profile/core";
+import { _ } from "@originator-profile/ui";
 import { useSearchParams } from "react-router";
 import GlobalHeader from "../components/GlobalHeader";
 import Loading from "../components/Loading";
@@ -8,16 +9,35 @@ import {
 } from "../components/siteProfile";
 import { routes } from "../utils/routes";
 
+function MissingSiteProfile() {
+  return (
+    <>
+      <GlobalHeader className="sticky top-0 z-11" />
+      <div className="bg-gray-50 p-4">
+        <h1
+          className="text-base text-center mb-6"
+          data-testid="site-profile-missing"
+        >
+          {_("SiteProfile_Missing")}
+        </h1>
+        <p className="whitespace-pre-line test-xs text-gray-700 text center leading-5">
+          {_("SiteProfile_Missing_Detail")}
+        </p>
+      </div>
+    </>
+  );
+}
+
 export default function SiteProfile() {
   const [queryParams] = useSearchParams();
   const { siteProfile, isLoading } = useSiteProfile();
   if (isLoading) return <Loading />;
   // Credential での CaSelector 部分とスタッキングコンテキストで下に重なってしまうため z-11 に設定
-  if (!siteProfile) return <GlobalHeader className="sticky top-0 z-11" />;
+  if (!siteProfile) return <MissingSiteProfile />;
 
   // sitesから適切なWebsiteProfileを選択
   const selectedWsp = selectByLocale(siteProfile.sites.map((s) => s.doc));
-  if (!selectedWsp) return <GlobalHeader className="sticky top-0 z-11" />;
+  if (!selectedWsp) return <MissingSiteProfile />;
 
   // 選択されたWebsiteProfileの発行者に対応するOriginatorを検索
   const op = siteProfile.originators.find((originator) =>

--- a/apps/inspector/src/pages/SiteProfile.tsx
+++ b/apps/inspector/src/pages/SiteProfile.tsx
@@ -21,7 +21,7 @@ function MissingSiteProfile() {
           {_("SiteProfile_Missing")}
         </h1>
         <p className="whitespace-pre-line text-xs text-gray-700 text-center leading-5">
-          {_("SiteProfile_Missing_Detail")}
+          {_("SiteProfile_Missing_Reason")}
         </p>
       </div>
     </>

--- a/apps/inspector/src/pages/SiteProfile.tsx
+++ b/apps/inspector/src/pages/SiteProfile.tsx
@@ -20,7 +20,7 @@ function MissingSiteProfile() {
         >
           {_("SiteProfile_Missing")}
         </h1>
-        <p className="whitespace-pre-line test-xs text-gray-700 text center leading-5">
+        <p className="whitespace-pre-line text-xs text-gray-700 text-center leading-5">
           {_("SiteProfile_Missing_Detail")}
         </p>
       </div>


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- CA だけで SP がない場合の表示を追加しました。

close #98 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- `pnpm e2e` にてテストが通ることをご確認ください。
- `pnpm dev` 後、`apps/inspector/dev/public/.well-known/sp.json` を削除した状態で拡張機能を使用し、http://localhost:8080/examples/cas-2.html 等にアクセス。
  「サイトプロファイルが見つかりませんでした」という表示が出ることをご確認ください。