### PR TITLE
feat(cas-client): writeCasFileを作成

### DIFF
--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -145,15 +145,14 @@ const renewed = await client.reSign(
 await writeCasFile({
   fileName: "ja-JP.page.cas.json",
   jwt,
-  outputDir: "dist/cas",
+  outputDir: "./dist/cas",
 });
 
 // output /path/to/site/dist/cas/ja-JP.page.cas.json
 await writeCasFile({
   fileName: "ja-JP.page.cas.json",
   jwt,
-  outputDir: "dist/cas",
-  baseDir: "/path/to/site",
+  outputDir: "/path/to/site/dist/cas",
 });
 ```
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -123,7 +123,7 @@ const jwt = await client.sign({
 });
 ```
 
-### resign
+### reSign
 
 `reSign` メソッドは、既存 CAS の JWT payload を再署名し、JWT 文字列を返します。第 2 引数 `source` はエラーメッセージの文脈（CAS ファイルパスなど）に使われます。
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -43,6 +43,7 @@ $ pnpm add @originator-profile/ca-client
 ```ts
 import {
   createCaClient,
+  writeCasFile,
   CaClientError,
   CaClientErrorCode,
   isUnauthorized,
@@ -74,6 +75,21 @@ const client = createCaClient({
 > [!NOTE]
 > `authType` は `client_secret_post` のみ対応しています。`clientSec` は OAuth の `client_secret` です。
 
+### Quick Start
+
+未署名 CA を CA サーバーで署名し、署名済み JWT を CAS ファイルとして書き出します。
+
+```ts
+const jwt = await client.sign(unsignedCa);
+
+// output dist/cas/ja-JP.hello.cas.json
+await writeCasFile({
+  fileName: "ja-JP.hello.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+});
+```
+
 ### APIメソッド
 
 | メソッド | 説明                                 |
@@ -81,7 +97,7 @@ const client = createCaClient({
 | `sign`   | 未署名 CA を CA サーバーで署名する   |
 | `reSign` | 既存 CAS の JWT payload を再署名する |
 
-### 未署名 CA の署名
+### sign
 
 `sign` メソッドは、未署名の Content Attestation を CA サーバーで署名し、JWT 文字列を返します。
 
@@ -107,7 +123,7 @@ const jwt = await client.sign({
 });
 ```
 
-### 既存 CAS の再署名
+### resign
 
 `reSign` メソッドは、既存 CAS の JWT payload を再署名し、JWT 文字列を返します。第 2 引数 `source` はエラーメッセージの文脈（CAS ファイルパスなど）に使われます。
 
@@ -119,6 +135,27 @@ const renewed = await client.reSign(
 ```
 
 `createCaClient` に渡した `issuer` が、payload の `issuer` より優先されます。
+
+### writeCasFile
+
+`writeCasFile` は、署名済み JWT を CAS ファイルとして書き出します。`fileName`・`jwt`・`outputDir` は必須です。
+
+```ts
+// output dist/cas/ja-JP.page.cas.json
+await writeCasFile({
+  fileName: "ja-JP.page.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+});
+
+// output /path/to/site/dist/cas/ja-JP.page.cas.json
+await writeCasFile({
+  fileName: "ja-JP.page.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+  baseDir: "/path/to/site",
+});
+```
 
 ### エラー
 
@@ -139,9 +176,10 @@ try {
 | --------------- | ---------------------------------------------------- |
 | `CA_CONFIG`     | CCSP 設定の欠落・不正、未対応の `authType`           |
 | `CA_AUTH`       | CCSP トークンエンドポイントの失敗（401 を含む）      |
-| `CA_VALIDATION` | 未署名 CA・CAS payload・日付の不正                   |
+| `CA_VALIDATION` | 未署名 CA・CAS payload・日付・パス・JWT の不正       |
 | `CA_HTTP`       | CA サーバーが非 2xx を返した、またはネットワーク障害 |
 | `CA_RESPONSE`   | CA サーバーの本文が空、または JWT を含まない         |
+| `CA_FILE`       | CAS ファイルの書き込み・削除に失敗した               |
 
 `sign()` / `reSign()` は CA サーバーが 401 を返したとき、アクセストークンを更新して 1 回だけ再試行します。再試行後も 401 なら `isUnauthorized(error)` が真になります。
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -82,11 +82,9 @@ const client = createCaClient({
 ```ts
 const jwt = await client.sign(unsignedCa);
 
-// output dist/cas/ja-JP.hello.cas.json
 await writeCasFile({
-  fileName: "ja-JP.hello.cas.json",
+  filePath: "dist/cas/ja-JP.hello.cas.json",
   jwt,
-  outputDir: "dist/cas",
 });
 ```
 
@@ -138,21 +136,17 @@ const renewed = await client.reSign(
 
 ### writeCasFile
 
-`writeCasFile` は、署名済み JWT を CAS ファイルとして書き出します。`fileName`・`jwt`・`outputDir` は必須です。
+`writeCasFile` は、署名済み JWT を CAS ファイルとして書き出します。`filePath`・`jwt` は必須です。
 
 ```ts
-// output dist/cas/ja-JP.page.cas.json
 await writeCasFile({
-  fileName: "ja-JP.page.cas.json",
+  filePath: "dist/cas/ja-JP.page.cas.json",
   jwt,
-  outputDir: "./dist/cas",
 });
 
-// output /path/to/site/dist/cas/ja-JP.page.cas.json
 await writeCasFile({
-  fileName: "ja-JP.page.cas.json",
+  filePath: "/path/to/site/dist/cas/ja-JP.page.cas.json",
   jwt,
-  outputDir: "/path/to/site/dist/cas",
 });
 ```
 

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -3,12 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 import { CaClientError, CaClientErrorCode } from "../errors";
-import {
-  casFilePath,
-  deleteCasFiles,
-  resolveCasDir,
-  writeCasFile,
-} from "./file";
+import { deleteCasFiles, resolveCasFilePath, writeCasFile } from "./file";
 
 const withTempDir = async (run: (dir: string) => Promise<void>) => {
   const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
@@ -22,106 +17,55 @@ const withTempDir = async (run: (dir: string) => Promise<void>) => {
 test("writeCasFile: writes JWT as a one-element JSON array with a trailing newline", async () => {
   await withTempDir(async (dir) => {
     const jwt = "test-jwt-token";
-    const outputDir = join(dir, "cas");
+    const filePath = join(dir, "cas", "test.cas.json");
 
-    await writeCasFile({
-      fileName: "test.cas.json",
-      jwt,
-      outputDir,
-    });
+    await writeCasFile({ filePath, jwt });
 
-    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
+    const written = await readFile(filePath, "utf8");
     expect(written).toBe(`${JSON.stringify([jwt], null, 2)}\n`);
   });
 });
 
-test("writeCasFile: creates nested directories from outputDir and fileName", async () => {
+test("writeCasFile: creates nested directories from filePath", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "out", "cas");
+    const filePath = join(dir, "out", "cas", "nested", "page.cas.json");
 
-    await writeCasFile({
-      fileName: "nested/page.cas.json",
-      jwt: "jwt-1",
-      outputDir,
-    });
+    await writeCasFile({ filePath, jwt: "jwt-1" });
 
-    const written = await readFile(
-      join(outputDir, "nested", "page.cas.json"),
-      "utf8",
-    );
+    const written = await readFile(filePath, "utf8");
     expect(JSON.parse(written)).toEqual(["jwt-1"]);
   });
 });
 
-test("writeCasFile: writes when outputDir already exists", async () => {
+test("writeCasFile: writes when the parent directory already exists", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
-    await mkdir(outputDir, { recursive: true });
+    const filePath = join(dir, "cas", "b.cas.json");
+    await mkdir(join(dir, "cas"), { recursive: true });
 
-    await writeCasFile({
-      fileName: "b.cas.json",
-      jwt: "jwt-b",
-      outputDir,
-    });
+    await writeCasFile({ filePath, jwt: "jwt-b" });
 
-    const written = await readFile(join(outputDir, "b.cas.json"), "utf8");
+    const written = await readFile(filePath, "utf8");
     expect(JSON.parse(written)).toEqual(["jwt-b"]);
   });
 });
 
-test("writeCasFile: rejects an empty outputDir", async () => {
+test("writeCasFile: rejects an empty filePath", async () => {
   await Promise.all(
-    ["", "   "].map((outputDir) =>
-      expect(
-        writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
-      ).rejects.toMatchObject({
+    ["", "   "].map((filePath) =>
+      expect(writeCasFile({ filePath, jwt: "jwt" })).rejects.toMatchObject({
         name: "CaClientError",
         code: CaClientErrorCode.Validation,
-        message: "outputDir must be a non-empty string",
+        message: "filePath must be a non-empty string",
       }),
     ),
   );
-});
-
-test("writeCasFile: rejects an empty fileName", async () => {
-  await Promise.all(
-    ["", "   "].map((fileName) =>
-      expect(
-        writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
-      ).rejects.toMatchObject({
-        name: "CaClientError",
-        code: CaClientErrorCode.Validation,
-        message: "fileName must be a non-empty string",
-      }),
-    ),
-  );
-});
-
-test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
-  await withTempDir(async (dir) => {
-    await expect(
-      writeCasFile({
-        fileName: "../outside.cas.json",
-        jwt: "jwt",
-        outputDir: join(dir, "cas"),
-      }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "fileName must stay inside outputDir",
-    });
-
-    await expect(
-      readFile(join(dir, "outside.cas.json"), "utf8"),
-    ).rejects.toMatchObject({ code: "ENOENT" });
-  });
 });
 
 test("writeCasFile: rejects an empty jwt", async () => {
   await Promise.all(
     ["", "   "].map((jwt) =>
       expect(
-        writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
+        writeCasFile({ filePath: "cas/a.cas.json", jwt }),
       ).rejects.toMatchObject({
         name: "CaClientError",
         code: CaClientErrorCode.Validation,
@@ -133,36 +77,22 @@ test("writeCasFile: rejects an empty jwt", async () => {
 
 test("writeCasFile: replaces an existing file with complete new content", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
+    const filePath = join(dir, "cas", "test.cas.json");
 
-    await writeCasFile({
-      fileName: "test.cas.json",
-      jwt: "old-jwt",
-      outputDir,
-    });
-    await writeCasFile({
-      fileName: "test.cas.json",
-      jwt: "new-jwt",
-      outputDir,
-    });
+    await writeCasFile({ filePath, jwt: "old-jwt" });
+    await writeCasFile({ filePath, jwt: "new-jwt" });
 
-    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
+    const written = await readFile(filePath, "utf8");
     expect(written).toBe(`${JSON.stringify(["new-jwt"], null, 2)}\n`);
   });
 });
 
 test("writeCasFile: wraps EISDIR when dest is a directory", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
-    await mkdir(join(outputDir, "test.cas.json"), { recursive: true });
+    const filePath = join(dir, "cas", "test.cas.json");
+    await mkdir(filePath, { recursive: true });
 
-    await expect(
-      writeCasFile({
-        fileName: "test.cas.json",
-        jwt: "jwt",
-        outputDir,
-      }),
-    ).rejects.toMatchObject({
+    await expect(writeCasFile({ filePath, jwt: "jwt" })).rejects.toMatchObject({
       name: "CaClientError",
       code: CaClientErrorCode.File,
     });
@@ -176,9 +106,8 @@ test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
 
     await expect(
       writeCasFile({
-        fileName: "a.cas.json",
+        filePath: join(blocker, "cas", "a.cas.json"),
         jwt: "jwt",
-        outputDir: join(blocker, "cas"),
       }),
     ).rejects.toMatchObject({
       name: "CaClientError",
@@ -189,140 +118,70 @@ test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
 
 test("deleteCasFiles: deletes existing CAS files", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
+    const keep = join(dir, "cas", "keep.cas.json");
+    const drop = join(dir, "cas", "drop.cas.json");
 
-    await writeCasFile({
-      fileName: "keep.cas.json",
-      jwt: "keep",
-      outputDir,
-    });
-    await writeCasFile({
-      fileName: "drop.cas.json",
-      jwt: "drop",
-      outputDir,
-    });
+    await writeCasFile({ filePath: keep, jwt: "keep" });
+    await writeCasFile({ filePath: drop, jwt: "drop" });
 
-    await deleteCasFiles(["drop.cas.json"], outputDir);
+    await deleteCasFiles([drop]);
 
-    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    const kept = await readFile(keep, "utf8");
     expect(JSON.parse(kept)).toEqual(["keep"]);
-    await expect(
-      readFile(join(outputDir, "drop.cas.json"), "utf8"),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(drop, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 });
 
 test("deleteCasFiles: skips missing files", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
-    await mkdir(outputDir, { recursive: true });
-
     await expect(
-      deleteCasFiles(["missing.cas.json"], outputDir),
+      deleteCasFiles([join(dir, "cas", "missing.cas.json")]),
     ).resolves.toBeUndefined();
   });
 });
 
 test("deleteCasFiles: does nothing for an empty list", async () => {
-  await withTempDir(async (dir) => {
-    await expect(deleteCasFiles([], join(dir, "cas"))).resolves.toBeUndefined();
-  });
+  await expect(deleteCasFiles([])).resolves.toBeUndefined();
 });
 
-test("deleteCasFiles: rejects an empty outputDir even for an empty list", async () => {
-  await Promise.all(
-    ["", "   "].map(async (outputDir) => {
-      await expect(
-        deleteCasFiles(["a.cas.json"], outputDir),
-      ).rejects.toMatchObject({
-        name: "CaClientError",
-        code: CaClientErrorCode.Validation,
-        message: "outputDir must be a non-empty string",
-      });
-      await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
-        name: "CaClientError",
-        code: CaClientErrorCode.Validation,
-        message: "outputDir must be a non-empty string",
-      });
-    }),
-  );
-});
-
-test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {
+test("deleteCasFiles: rejects an empty filePath before deleting any files", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
+    const keep = join(dir, "cas", "keep.cas.json");
+    await writeCasFile({ filePath: keep, jwt: "keep" });
 
-    await writeCasFile({
-      fileName: "keep.cas.json",
-      jwt: "keep",
-      outputDir,
-    });
-    const outside = join(dir, "outside.cas.json");
-    await writeFile(outside, "secret");
-
-    await expect(
-      deleteCasFiles(["keep.cas.json", "../outside.cas.json"], outputDir),
-    ).rejects.toMatchObject({
+    await expect(deleteCasFiles([keep, ""])).rejects.toMatchObject({
       name: "CaClientError",
       code: CaClientErrorCode.Validation,
-      message: "fileName must stay inside outputDir",
+      message: "filePath must be a non-empty string",
     });
-
-    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
-    expect(JSON.parse(kept)).toEqual(["keep"]);
-    expect(await readFile(outside, "utf8")).toBe("secret");
-  });
-});
-
-test("deleteCasFiles: rejects an empty fileName before deleting any files", async () => {
-  await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
-
-    await writeCasFile({
-      fileName: "keep.cas.json",
-      jwt: "keep",
-      outputDir,
-    });
-
-    await expect(
-      deleteCasFiles(["keep.cas.json", ""], outputDir),
-    ).rejects.toMatchObject({
+    await expect(deleteCasFiles([keep, "   "])).rejects.toMatchObject({
       name: "CaClientError",
       code: CaClientErrorCode.Validation,
-      message: "fileName must be a non-empty string",
-    });
-    await expect(
-      deleteCasFiles(["keep.cas.json", "   "], outputDir),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "fileName must be a non-empty string",
+      message: "filePath must be a non-empty string",
     });
 
-    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    const kept = await readFile(keep, "utf8");
     expect(JSON.parse(kept)).toEqual(["keep"]);
   });
 });
 
 test("deleteCasFiles: deletes multiple CAS files", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "cas");
-    const names = ["one.cas.json", "two.cas.json"];
+    const filePaths = [
+      join(dir, "cas", "one.cas.json"),
+      join(dir, "cas", "two.cas.json"),
+    ];
     await Promise.all(
-      names.map((fileName) =>
-        writeCasFile({
-          fileName,
-          jwt: fileName,
-          outputDir,
-        }),
-      ),
+      filePaths.map((filePath) => writeCasFile({ filePath, jwt: filePath })),
     );
 
-    await deleteCasFiles(names, outputDir);
+    await deleteCasFiles(filePaths);
 
     await Promise.all(
-      names.map((name) =>
-        expect(readFile(join(outputDir, name), "utf8")).rejects.toMatchObject({
+      filePaths.map((filePath) =>
+        expect(readFile(filePath, "utf8")).rejects.toMatchObject({
           code: "ENOENT",
         }),
       ),
@@ -330,66 +189,26 @@ test("deleteCasFiles: deletes multiple CAS files", async () => {
   });
 });
 
-test("casFilePath: keeps nested fileName inside outputDir", () => {
-  expect(
-    casFilePath({
-      fileName: "nested/page.cas.json",
-      outputDir: "/workspace/cas",
-    }),
-  ).toBe(resolve("/workspace", "cas", "nested", "page.cas.json"));
-});
-
-test("casFilePath: allows a fileName whose .. segments stay inside outputDir", () => {
-  expect(
-    casFilePath({
-      fileName: "nested/../page.cas.json",
-      outputDir: "/workspace/cas",
-    }),
-  ).toBe(resolve("/workspace", "cas", "page.cas.json"));
-});
-
-test("casFilePath: rejects a fileName that escapes outputDir", () => {
-  for (const fileName of [
-    "../outside.cas.json",
-    "../../etc/passwd",
-    "nested/../../outside.cas.json",
-    "/etc/passwd",
-    ".",
-    "..",
-  ]) {
-    expect(() =>
-      casFilePath({ fileName, outputDir: "/workspace/cas" }),
-    ).toThrow("fileName must stay inside outputDir");
-  }
-});
-
-test("casFilePath: does not treat a name starting with .. as traversal", () => {
-  expect(
-    casFilePath({
-      fileName: "..page.cas.json",
-      outputDir: "/workspace/cas",
-    }),
-  ).toBe(resolve("/workspace", "cas", "..page.cas.json"));
-});
-
-test("resolveCasDir: resolves a relative path against process.cwd()", () => {
-  expect(resolveCasDir("public/cas")).toBe(
-    resolve(process.cwd(), "public", "cas"),
+test("resolveCasFilePath: resolves a relative path against process.cwd()", () => {
+  expect(resolveCasFilePath("dist/cas/page.cas.json")).toBe(
+    resolve(process.cwd(), "dist", "cas", "page.cas.json"),
   );
-  expect(resolveCasDir("./public/cas")).toBe(
-    resolve(process.cwd(), "public", "cas"),
+  expect(resolveCasFilePath("./dist/cas/page.cas.json")).toBe(
+    resolve(process.cwd(), "dist", "cas", "page.cas.json"),
   );
 });
 
-test("resolveCasDir: returns an absolute path unchanged", () => {
-  expect(resolveCasDir("/abs/cas")).toBe(resolve("/abs/cas"));
+test("resolveCasFilePath: returns an absolute path unchanged", () => {
+  expect(resolveCasFilePath("/abs/cas/page.cas.json")).toBe(
+    resolve("/abs/cas/page.cas.json"),
+  );
 });
 
-test("resolveCasDir: rejects an empty path so it is not resolved to the root", () => {
-  for (const outputDir of ["", "   "]) {
-    expect(() => resolveCasDir(outputDir)).toThrow(CaClientError);
-    expect(() => resolveCasDir(outputDir)).toThrow(
-      "outputDir must be a non-empty string",
+test("resolveCasFilePath: rejects an empty path so it is not resolved to cwd", () => {
+  for (const filePath of ["", "   "]) {
+    expect(() => resolveCasFilePath(filePath)).toThrow(CaClientError);
+    expect(() => resolveCasFilePath(filePath)).toThrow(
+      "filePath must be a non-empty string",
     );
   }
 });

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect, test } from "vitest";
+import { CaClientError, CaClientErrorCode } from "../errors";
+import { deleteCasFiles, resolveCasDir, writeCasFile } from "./file";
+
+const withTempDir = async (run: (dir: string) => Promise<void>) => {
+  const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+test("writeCasFile: writes JWT as a one-element JSON array with a trailing newline", async () => {
+  await withTempDir(async (dir) => {
+    const jwt = "test-jwt-token";
+
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt,
+      outputDir: "cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(join(dir, "cas", "test.cas.json"), "utf8");
+    expect(written).toBe(`${JSON.stringify([jwt], null, 2)}\n`);
+  });
+});
+
+test("writeCasFile: creates nested directories from outputDir and fileName", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "nested/page.cas.json",
+      jwt: "jwt-1",
+      outputDir: "out/cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(
+      join(dir, "out", "cas", "nested", "page.cas.json"),
+      "utf8",
+    );
+    expect(JSON.parse(written)).toEqual(["jwt-1"]);
+  });
+});
+
+test("writeCasFile: resolves relative outputDir against the baseDir option", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "a.cas.json",
+      jwt: "jwt-a",
+      outputDir: "relative/cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(
+      join(dir, "relative", "cas", "a.cas.json"),
+      "utf8",
+    );
+    expect(JSON.parse(written)).toEqual(["jwt-a"]);
+  });
+});
+
+test("writeCasFile: uses an absolute outputDir as-is", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "absolute", "cas");
+
+    await writeCasFile({
+      fileName: "b.cas.json",
+      jwt: "jwt-b",
+      outputDir,
+      baseDir: "/unused",
+    });
+
+    const written = await readFile(join(outputDir, "b.cas.json"), "utf8");
+    expect(JSON.parse(written)).toEqual(["jwt-b"]);
+  });
+});
+
+test("writeCasFile: rejects an empty outputDir", async () => {
+  await expect(
+    writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir: "" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "outputDir must be a non-empty string",
+  });
+});
+
+test("writeCasFile: rejects an empty fileName", async () => {
+  await expect(
+    writeCasFile({ fileName: "", jwt: "jwt", outputDir: "cas" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "fileName must be a non-empty string",
+  });
+});
+
+test("writeCasFile: rejects an empty jwt", async () => {
+  await expect(
+    writeCasFile({ fileName: "a.cas.json", jwt: "", outputDir: "cas" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "jwt must be a non-empty string",
+  });
+});
+
+test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
+  await withTempDir(async (dir) => {
+    const blocker = join(dir, "not-a-dir");
+    await writeFile(blocker, "file");
+
+    await expect(
+      writeCasFile({
+        fileName: "a.cas.json",
+        jwt: "jwt",
+        outputDir: join(blocker, "cas"),
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.File,
+    });
+  });
+});
+
+test("deleteCasFiles: deletes existing CAS files", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir: "cas",
+      baseDir: dir,
+    });
+    await writeCasFile({
+      fileName: "drop.cas.json",
+      jwt: "drop",
+      outputDir: "cas",
+      baseDir: dir,
+    });
+
+    await deleteCasFiles(["drop.cas.json"], { outputDir: "cas", baseDir: dir });
+
+    const kept = await readFile(join(dir, "cas", "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+    await expect(
+      readFile(join(dir, "cas", "drop.cas.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+test("deleteCasFiles: skips missing files", async () => {
+  await withTempDir(async (dir) => {
+    await mkdir(join(dir, "cas"), { recursive: true });
+
+    await expect(
+      deleteCasFiles(["missing.cas.json"], { outputDir: "cas", baseDir: dir }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+test("deleteCasFiles: does nothing for an empty list", async () => {
+  await expect(deleteCasFiles([], { outputDir: "" })).resolves.toBeUndefined();
+});
+
+test("deleteCasFiles: deletes multiple CAS files", async () => {
+  await withTempDir(async (dir) => {
+    const names = ["one.cas.json", "two.cas.json"];
+    await Promise.all(
+      names.map((fileName) =>
+        writeCasFile({
+          fileName,
+          jwt: fileName,
+          outputDir: "cas",
+          baseDir: dir,
+        }),
+      ),
+    );
+
+    await deleteCasFiles(names, { outputDir: "cas", baseDir: dir });
+
+    await Promise.all(
+      names.map((name) =>
+        expect(readFile(join(dir, "cas", name), "utf8")).rejects.toMatchObject({
+          code: "ENOENT",
+        }),
+      ),
+    );
+  });
+});
+
+test("resolveCasDir: resolves a relative path against baseDir", () => {
+  const dir = resolveCasDir({ outputDir: "public/cas", baseDir: "/workspace" });
+  expect(dir).toBe(resolve("/workspace", "public", "cas"));
+});
+
+test("resolveCasDir: defaults to process.cwd() for relative paths", () => {
+  expect(resolveCasDir({ outputDir: "public/cas" })).toBe(
+    resolve(process.cwd(), "public", "cas"),
+  );
+});
+
+test("resolveCasDir: returns an absolute path unchanged", () => {
+  expect(resolveCasDir({ outputDir: "/abs/cas", baseDir: "/workspace" })).toBe(
+    resolve("/abs/cas"),
+  );
+});
+
+test("resolveCasDir: rejects an empty path so it is not resolved to the root", () => {
+  expect(() => resolveCasDir({ outputDir: "" })).toThrow(CaClientError);
+  expect(() => resolveCasDir({ outputDir: "" })).toThrow(
+    "outputDir must be a non-empty string",
+  );
+});

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -154,7 +154,7 @@ test("writeCasFile: replaces an existing file with complete new content", async 
   });
 });
 
-test("writeCasFile: removes the temp file when rename cannot replace dest", async () => {
+test("writeCasFile: wraps EISDIR when dest is a directory", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "cas");
     await mkdir(join(outputDir, "test.cas.json"), { recursive: true });

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -60,7 +60,7 @@ test("writeCasFile: creates nested directories from outputDir and fileName", asy
   });
 });
 
-test("writeCasFile: uses an absolute outputDir as-is", async () => {
+test("writeCasFile: writes to a deeply nested absolute outputDir", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "absolute", "cas");
 

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -70,27 +70,31 @@ test("writeCasFile: writes when outputDir already exists", async () => {
 });
 
 test("writeCasFile: rejects an empty outputDir", async () => {
-  for (const outputDir of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((outputDir) =>
+      expect(
+        writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: rejects an empty fileName", async () => {
-  for (const fileName of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "fileName must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((fileName) =>
+      expect(
+        writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "fileName must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
@@ -114,15 +118,17 @@ test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
 });
 
 test("writeCasFile: rejects an empty jwt", async () => {
-  for (const jwt of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "jwt must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((jwt) =>
+      expect(
+        writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "jwt must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: replaces an existing file with complete new content", async () => {
@@ -224,20 +230,22 @@ test("deleteCasFiles: does nothing for an empty list", async () => {
 });
 
 test("deleteCasFiles: rejects an empty outputDir even for an empty list", async () => {
-  for (const outputDir of ["", "   "]) {
-    await expect(
-      deleteCasFiles(["a.cas.json"], outputDir),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-    await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map(async (outputDir) => {
+      await expect(
+        deleteCasFiles(["a.cas.json"], outputDir),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      });
+      await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      });
+    }),
+  );
 });
 
 test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,11 +1,4 @@
-import {
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
@@ -60,9 +53,10 @@ test("writeCasFile: creates nested directories from outputDir and fileName", asy
   });
 });
 
-test("writeCasFile: writes to a deeply nested absolute outputDir", async () => {
+test("writeCasFile: writes when outputDir already exists", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "absolute", "cas");
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
 
     await writeCasFile({
       fileName: "b.cas.json",
@@ -148,9 +142,6 @@ test("writeCasFile: replaces an existing file with complete new content", async 
 
     const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
     expect(written).toBe(`${JSON.stringify(["new-jwt"], null, 2)}\n`);
-    expect(
-      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
-    ).toEqual([]);
   });
 });
 
@@ -169,10 +160,6 @@ test("writeCasFile: wraps EISDIR when dest is a directory", async () => {
       name: "CaClientError",
       code: CaClientErrorCode.File,
     });
-
-    expect(
-      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
-    ).toEqual([]);
   });
 });
 

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
@@ -124,6 +131,51 @@ test("writeCasFile: rejects an empty jwt", async () => {
   }
 });
 
+test("writeCasFile: replaces an existing file with complete new content", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt: "old-jwt",
+      outputDir,
+    });
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt: "new-jwt",
+      outputDir,
+    });
+
+    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
+    expect(written).toBe(`${JSON.stringify(["new-jwt"], null, 2)}\n`);
+    expect(
+      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+  });
+});
+
+test("writeCasFile: removes the temp file when rename cannot replace dest", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await mkdir(join(outputDir, "test.cas.json"), { recursive: true });
+
+    await expect(
+      writeCasFile({
+        fileName: "test.cas.json",
+        jwt: "jwt",
+        outputDir,
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.File,
+    });
+
+    expect(
+      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+  });
+});
+
 test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
   await withTempDir(async (dir) => {
     const blocker = join(dir, "not-a-dir");
@@ -179,7 +231,26 @@ test("deleteCasFiles: skips missing files", async () => {
 });
 
 test("deleteCasFiles: does nothing for an empty list", async () => {
-  await expect(deleteCasFiles([], "")).resolves.toBeUndefined();
+  await withTempDir(async (dir) => {
+    await expect(deleteCasFiles([], join(dir, "cas"))).resolves.toBeUndefined();
+  });
+});
+
+test("deleteCasFiles: rejects an empty outputDir even for an empty list", async () => {
+  for (const outputDir of ["", "   "]) {
+    await expect(
+      deleteCasFiles(["a.cas.json"], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+    await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+  }
 });
 
 test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 import { CaClientError, CaClientErrorCode } from "../errors";
-import { deleteCasFiles, resolveCasDir, writeCasFile } from "./file";
+import {
+  casFilePath,
+  deleteCasFiles,
+  resolveCasDir,
+  writeCasFile,
+} from "./file";
 
 const withTempDir = async (run: (dir: string) => Promise<void>) => {
   const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
@@ -17,50 +22,34 @@ const withTempDir = async (run: (dir: string) => Promise<void>) => {
 test("writeCasFile: writes JWT as a one-element JSON array with a trailing newline", async () => {
   await withTempDir(async (dir) => {
     const jwt = "test-jwt-token";
+    const outputDir = join(dir, "cas");
 
     await writeCasFile({
       fileName: "test.cas.json",
       jwt,
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
 
-    const written = await readFile(join(dir, "cas", "test.cas.json"), "utf8");
+    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
     expect(written).toBe(`${JSON.stringify([jwt], null, 2)}\n`);
   });
 });
 
 test("writeCasFile: creates nested directories from outputDir and fileName", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "out", "cas");
+
     await writeCasFile({
       fileName: "nested/page.cas.json",
       jwt: "jwt-1",
-      outputDir: "out/cas",
-      baseDir: dir,
+      outputDir,
     });
 
     const written = await readFile(
-      join(dir, "out", "cas", "nested", "page.cas.json"),
+      join(outputDir, "nested", "page.cas.json"),
       "utf8",
     );
     expect(JSON.parse(written)).toEqual(["jwt-1"]);
-  });
-});
-
-test("writeCasFile: resolves relative outputDir against the baseDir option", async () => {
-  await withTempDir(async (dir) => {
-    await writeCasFile({
-      fileName: "a.cas.json",
-      jwt: "jwt-a",
-      outputDir: "relative/cas",
-      baseDir: dir,
-    });
-
-    const written = await readFile(
-      join(dir, "relative", "cas", "a.cas.json"),
-      "utf8",
-    );
-    expect(JSON.parse(written)).toEqual(["jwt-a"]);
   });
 });
 
@@ -72,7 +61,6 @@ test("writeCasFile: uses an absolute outputDir as-is", async () => {
       fileName: "b.cas.json",
       jwt: "jwt-b",
       outputDir,
-      baseDir: "/unused",
     });
 
     const written = await readFile(join(outputDir, "b.cas.json"), "utf8");
@@ -81,33 +69,59 @@ test("writeCasFile: uses an absolute outputDir as-is", async () => {
 });
 
 test("writeCasFile: rejects an empty outputDir", async () => {
-  await expect(
-    writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir: "" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "outputDir must be a non-empty string",
-  });
+  for (const outputDir of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+  }
 });
 
 test("writeCasFile: rejects an empty fileName", async () => {
-  await expect(
-    writeCasFile({ fileName: "", jwt: "jwt", outputDir: "cas" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "fileName must be a non-empty string",
+  for (const fileName of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+  }
+});
+
+test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
+  await withTempDir(async (dir) => {
+    await expect(
+      writeCasFile({
+        fileName: "../outside.cas.json",
+        jwt: "jwt",
+        outputDir: join(dir, "cas"),
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must stay inside outputDir",
+    });
+
+    await expect(
+      readFile(join(dir, "outside.cas.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 
 test("writeCasFile: rejects an empty jwt", async () => {
-  await expect(
-    writeCasFile({ fileName: "a.cas.json", jwt: "", outputDir: "cas" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "jwt must be a non-empty string",
-  });
+  for (const jwt of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "jwt must be a non-empty string",
+    });
+  }
 });
 
 test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
@@ -130,62 +144,119 @@ test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
 
 test("deleteCasFiles: deletes existing CAS files", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
     await writeCasFile({
       fileName: "keep.cas.json",
       jwt: "keep",
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
     await writeCasFile({
       fileName: "drop.cas.json",
       jwt: "drop",
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
 
-    await deleteCasFiles(["drop.cas.json"], { outputDir: "cas", baseDir: dir });
+    await deleteCasFiles(["drop.cas.json"], outputDir);
 
-    const kept = await readFile(join(dir, "cas", "keep.cas.json"), "utf8");
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
     expect(JSON.parse(kept)).toEqual(["keep"]);
     await expect(
-      readFile(join(dir, "cas", "drop.cas.json"), "utf8"),
+      readFile(join(outputDir, "drop.cas.json"), "utf8"),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 
 test("deleteCasFiles: skips missing files", async () => {
   await withTempDir(async (dir) => {
-    await mkdir(join(dir, "cas"), { recursive: true });
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
 
     await expect(
-      deleteCasFiles(["missing.cas.json"], { outputDir: "cas", baseDir: dir }),
+      deleteCasFiles(["missing.cas.json"], outputDir),
     ).resolves.toBeUndefined();
   });
 });
 
 test("deleteCasFiles: does nothing for an empty list", async () => {
-  await expect(deleteCasFiles([], { outputDir: "" })).resolves.toBeUndefined();
+  await expect(deleteCasFiles([], "")).resolves.toBeUndefined();
+});
+
+test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir,
+    });
+    const outside = join(dir, "outside.cas.json");
+    await writeFile(outside, "secret");
+
+    await expect(
+      deleteCasFiles(["keep.cas.json", "../outside.cas.json"], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must stay inside outputDir",
+    });
+
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+    expect(await readFile(outside, "utf8")).toBe("secret");
+  });
+});
+
+test("deleteCasFiles: rejects an empty fileName before deleting any files", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir,
+    });
+
+    await expect(
+      deleteCasFiles(["keep.cas.json", ""], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+    await expect(
+      deleteCasFiles(["keep.cas.json", "   "], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+  });
 });
 
 test("deleteCasFiles: deletes multiple CAS files", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
     const names = ["one.cas.json", "two.cas.json"];
     await Promise.all(
       names.map((fileName) =>
         writeCasFile({
           fileName,
           jwt: fileName,
-          outputDir: "cas",
-          baseDir: dir,
+          outputDir,
         }),
       ),
     );
 
-    await deleteCasFiles(names, { outputDir: "cas", baseDir: dir });
+    await deleteCasFiles(names, outputDir);
 
     await Promise.all(
       names.map((name) =>
-        expect(readFile(join(dir, "cas", name), "utf8")).rejects.toMatchObject({
+        expect(readFile(join(outputDir, name), "utf8")).rejects.toMatchObject({
           code: "ENOENT",
         }),
       ),
@@ -193,26 +264,66 @@ test("deleteCasFiles: deletes multiple CAS files", async () => {
   });
 });
 
-test("resolveCasDir: resolves a relative path against baseDir", () => {
-  const dir = resolveCasDir({ outputDir: "public/cas", baseDir: "/workspace" });
-  expect(dir).toBe(resolve("/workspace", "public", "cas"));
+test("casFilePath: keeps nested fileName inside outputDir", () => {
+  expect(
+    casFilePath({
+      fileName: "nested/page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "nested", "page.cas.json"));
 });
 
-test("resolveCasDir: defaults to process.cwd() for relative paths", () => {
-  expect(resolveCasDir({ outputDir: "public/cas" })).toBe(
+test("casFilePath: allows a fileName whose .. segments stay inside outputDir", () => {
+  expect(
+    casFilePath({
+      fileName: "nested/../page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "page.cas.json"));
+});
+
+test("casFilePath: rejects a fileName that escapes outputDir", () => {
+  for (const fileName of [
+    "../outside.cas.json",
+    "../../etc/passwd",
+    "nested/../../outside.cas.json",
+    "/etc/passwd",
+    ".",
+    "..",
+  ]) {
+    expect(() =>
+      casFilePath({ fileName, outputDir: "/workspace/cas" }),
+    ).toThrow("fileName must stay inside outputDir");
+  }
+});
+
+test("casFilePath: does not treat a name starting with .. as traversal", () => {
+  expect(
+    casFilePath({
+      fileName: "..page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "..page.cas.json"));
+});
+
+test("resolveCasDir: resolves a relative path against process.cwd()", () => {
+  expect(resolveCasDir("public/cas")).toBe(
+    resolve(process.cwd(), "public", "cas"),
+  );
+  expect(resolveCasDir("./public/cas")).toBe(
     resolve(process.cwd(), "public", "cas"),
   );
 });
 
 test("resolveCasDir: returns an absolute path unchanged", () => {
-  expect(resolveCasDir({ outputDir: "/abs/cas", baseDir: "/workspace" })).toBe(
-    resolve("/abs/cas"),
-  );
+  expect(resolveCasDir("/abs/cas")).toBe(resolve("/abs/cas"));
 });
 
 test("resolveCasDir: rejects an empty path so it is not resolved to the root", () => {
-  expect(() => resolveCasDir({ outputDir: "" })).toThrow(CaClientError);
-  expect(() => resolveCasDir({ outputDir: "" })).toThrow(
-    "outputDir must be a non-empty string",
-  );
+  for (const outputDir of ["", "   "]) {
+    expect(() => resolveCasDir(outputDir)).toThrow(CaClientError);
+    expect(() => resolveCasDir(outputDir)).toThrow(
+      "outputDir must be a non-empty string",
+    );
+  }
 });

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
@@ -90,16 +89,11 @@ export const writeCasFile = async ({
   }
   const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
-  // Same-directory temp + rename so dest is never a truncated JWT CAS file
-  // if the process is killed or the disk fills mid-write.
-  const tmp = `${dest}.${randomUUID()}.tmp`;
 
   try {
     await mkdir(dirname(dest), { recursive: true });
-    await writeFile(tmp, casContent, "utf8");
-    await rename(tmp, dest);
+    await writeFile(dest, casContent, "utf8");
   } catch (error) {
-    await unlink(tmp).catch(() => {});
     throw toFileError(`Failed to write CAS file ${dest}`, error);
   }
 };

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,25 +1,18 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { dirname, resolve } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
 export type WriteCasFileOptions = {
-  /** CAS file name relative to `outputDir`, e.g. `ja-JP.page.cas.json`. */
-  fileName: string;
+  /**
+   * Destination CAS file path, e.g. `dist/cas/ja-JP.page.cas.json`.
+   * Relative paths resolve against the current working directory.
+   */
+  filePath: string;
   /** Signed JWT string to write. */
   jwt: string;
-  /**
-   * Output directory. Relative paths (e.g. `./dist/cas`) resolve against
-   * the current working directory. Absolute paths are used as-is.
-   */
-  outputDir: string;
 };
 
 const isEmpty = (value: string): boolean => value.trim() === "";
-
-const isInsideCasDir = (dir: string, dest: string): boolean => {
-  const rel = relative(dir, dest);
-  return rel !== "" && !isAbsolute(rel) && !rel.split(sep).includes("..");
-};
 
 const isEnoent = (error: unknown): boolean =>
   typeof error === "object" &&
@@ -48,46 +41,26 @@ const unlinkMissing = async (filePath: string): Promise<void> => {
   }
 };
 
-/** Resolve a CAS output directory. Relative paths use the current working directory. */
-export const resolveCasDir = (outputDir: string): string => {
-  if (isEmpty(outputDir)) {
-    throw new CaClientError("outputDir must be a non-empty string", {
+/** Resolve a CAS file path. Relative paths use the current working directory. */
+export const resolveCasFilePath = (filePath: string): string => {
+  if (isEmpty(filePath)) {
+    throw new CaClientError("filePath must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  return resolve(outputDir);
-};
-
-export const casFilePath = ({
-  fileName,
-  outputDir,
-}: Pick<WriteCasFileOptions, "fileName" | "outputDir">): string => {
-  if (isEmpty(fileName)) {
-    throw new CaClientError("fileName must be a non-empty string", {
-      code: CaClientErrorCode.Validation,
-    });
-  }
-  const dir = resolveCasDir(outputDir);
-  const dest = resolve(dir, fileName);
-  if (!isInsideCasDir(dir, dest)) {
-    throw new CaClientError("fileName must stay inside outputDir", {
-      code: CaClientErrorCode.Validation,
-    });
-  }
-  return dest;
+  return resolve(filePath);
 };
 
 export const writeCasFile = async ({
-  fileName,
+  filePath,
   jwt,
-  outputDir,
 }: WriteCasFileOptions): Promise<void> => {
   if (isEmpty(jwt)) {
     throw new CaClientError("jwt must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  const dest = casFilePath({ fileName, outputDir });
+  const dest = resolveCasFilePath(filePath);
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
 
   try {
@@ -98,18 +71,12 @@ export const writeCasFile = async ({
   }
 };
 
-export const deleteCasFiles = async (
-  fileNames: string[],
-  outputDir: string,
-): Promise<void> => {
-  const dir = resolveCasDir(outputDir);
-  if (fileNames.length === 0) {
+export const deleteCasFiles = async (filePaths: string[]): Promise<void> => {
+  if (filePaths.length === 0) {
     return;
   }
 
-  const dests = fileNames.map((fileName) =>
-    casFilePath({ fileName, outputDir: dir }),
-  );
+  const dests = filePaths.map((filePath) => resolveCasFilePath(filePath));
 
-  await Promise.all(dests.map((filePath) => unlinkMissing(filePath)));
+  await Promise.all(dests.map((dest) => unlinkMissing(dest)));
 };

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,4 +1,5 @@
-import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
@@ -89,11 +90,16 @@ export const writeCasFile = async ({
   }
   const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
+  // Same-directory temp + rename so dest is never a truncated JWT CAS file
+  // if the process is killed or the disk fills mid-write.
+  const tmp = `${dest}.${randomUUID()}.tmp`;
 
   try {
     await mkdir(dirname(dest), { recursive: true });
-    await writeFile(dest, casContent, "utf8");
+    await writeFile(tmp, casContent, "utf8");
+    await rename(tmp, dest);
   } catch (error) {
+    await unlink(tmp).catch(() => {});
     throw toFileError(`Failed to write CAS file ${dest}`, error);
   }
 };
@@ -102,12 +108,13 @@ export const deleteCasFiles = async (
   fileNames: string[],
   outputDir: string,
 ): Promise<void> => {
+  const dir = resolveCasDir(outputDir);
   if (fileNames.length === 0) {
     return;
   }
 
   const dests = fileNames.map((fileName) =>
-    casFilePath({ fileName, outputDir }),
+    casFilePath({ fileName, outputDir: dir }),
   );
 
   await Promise.all(dests.map((filePath) => unlinkMissing(filePath)));

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,27 +1,25 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
 export type WriteCasFileOptions = {
-  /** CAS file name, e.g. `ja-JP.page.cas.json`. */
+  /** CAS file name relative to `outputDir`, e.g. `ja-JP.page.cas.json`. */
   fileName: string;
   /** Signed JWT string to write. */
   jwt: string;
   /**
-   * Output directory. Relative paths resolve against `baseDir`
-   * (or the current working directory if omitted).
+   * Output directory. Relative paths (e.g. `./dist/cas`) resolve against
+   * the current working directory. Absolute paths are used as-is.
    */
   outputDir: string;
-  /**
-   * Base directory for a relative `outputDir`.
-   * Defaults to the current working directory.
-   */
-  baseDir?: string;
 };
 
-type CasDirOptions = Pick<WriteCasFileOptions, "outputDir" | "baseDir">;
+const isEmpty = (value: string): boolean => value.trim() === "";
 
-const isEmpty = (value: string): boolean => value === "";
+const isInsideCasDir = (dir: string, dest: string): boolean => {
+  const rel = relative(dir, dest);
+  return rel !== "" && !isAbsolute(rel) && !rel.split(sep).includes("..");
+};
 
 const isEnoent = (error: unknown): boolean =>
   typeof error === "object" &&
@@ -50,44 +48,46 @@ const unlinkMissing = async (filePath: string): Promise<void> => {
   }
 };
 
-/** Resolve a CAS output directory. Relative paths use `baseDir` or the current working directory. */
-export const resolveCasDir = ({
-  outputDir,
-  baseDir,
-}: CasDirOptions): string => {
+/** Resolve a CAS output directory. Relative paths use the current working directory. */
+export const resolveCasDir = (outputDir: string): string => {
   if (isEmpty(outputDir)) {
     throw new CaClientError("outputDir must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  return resolve(baseDir ?? process.cwd(), outputDir);
+  return resolve(outputDir);
 };
 
 export const casFilePath = ({
   fileName,
   outputDir,
-  baseDir,
-}: Pick<WriteCasFileOptions, "fileName" | "outputDir" | "baseDir">): string => {
+}: Pick<WriteCasFileOptions, "fileName" | "outputDir">): string => {
   if (isEmpty(fileName)) {
     throw new CaClientError("fileName must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  return join(resolveCasDir({ outputDir, baseDir }), fileName);
+  const dir = resolveCasDir(outputDir);
+  const dest = resolve(dir, fileName);
+  if (!isInsideCasDir(dir, dest)) {
+    throw new CaClientError("fileName must stay inside outputDir", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return dest;
 };
 
 export const writeCasFile = async ({
   fileName,
   jwt,
   outputDir,
-  baseDir,
 }: WriteCasFileOptions): Promise<void> => {
   if (isEmpty(jwt)) {
     throw new CaClientError("jwt must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  const dest = casFilePath({ fileName, outputDir, baseDir });
+  const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
 
   try {
@@ -100,22 +100,15 @@ export const writeCasFile = async ({
 
 export const deleteCasFiles = async (
   fileNames: string[],
-  { outputDir, baseDir }: CasDirOptions,
+  outputDir: string,
 ): Promise<void> => {
   if (fileNames.length === 0) {
     return;
   }
 
-  const dir = resolveCasDir({ outputDir, baseDir });
-
-  await Promise.all(
-    fileNames.map((fileName) => {
-      if (isEmpty(fileName)) {
-        throw new CaClientError("fileName must be a non-empty string", {
-          code: CaClientErrorCode.Validation,
-        });
-      }
-      return unlinkMissing(join(dir, fileName));
-    }),
+  const dests = fileNames.map((fileName) =>
+    casFilePath({ fileName, outputDir }),
   );
+
+  await Promise.all(dests.map((filePath) => unlinkMissing(filePath)));
 };

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,0 +1,121 @@
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { CaClientError, CaClientErrorCode } from "../errors";
+
+export type WriteCasFileOptions = {
+  /** CAS file name, e.g. `ja-JP.page.cas.json`. */
+  fileName: string;
+  /** Signed JWT string to write. */
+  jwt: string;
+  /**
+   * Output directory. Relative paths resolve against `baseDir`
+   * (or the current working directory if omitted).
+   */
+  outputDir: string;
+  /**
+   * Base directory for a relative `outputDir`.
+   * Defaults to the current working directory.
+   */
+  baseDir?: string;
+};
+
+type CasDirOptions = Pick<WriteCasFileOptions, "outputDir" | "baseDir">;
+
+const isEmpty = (value: string): boolean => value === "";
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "ENOENT";
+
+const toFileError = (message: string, error: unknown): CaClientError => {
+  if (error instanceof CaClientError) {
+    return error;
+  }
+  return new CaClientError(
+    `${message}: ${error instanceof Error ? error.message : String(error)}`,
+    { code: CaClientErrorCode.File, cause: error },
+  );
+};
+
+const unlinkMissing = async (filePath: string): Promise<void> => {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return;
+    }
+    throw toFileError(`Failed to delete CAS file ${filePath}`, error);
+  }
+};
+
+/** Resolve a CAS output directory. Relative paths use `baseDir` or the current working directory. */
+export const resolveCasDir = ({
+  outputDir,
+  baseDir,
+}: CasDirOptions): string => {
+  if (isEmpty(outputDir)) {
+    throw new CaClientError("outputDir must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return resolve(baseDir ?? process.cwd(), outputDir);
+};
+
+export const casFilePath = ({
+  fileName,
+  outputDir,
+  baseDir,
+}: Pick<WriteCasFileOptions, "fileName" | "outputDir" | "baseDir">): string => {
+  if (isEmpty(fileName)) {
+    throw new CaClientError("fileName must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return join(resolveCasDir({ outputDir, baseDir }), fileName);
+};
+
+export const writeCasFile = async ({
+  fileName,
+  jwt,
+  outputDir,
+  baseDir,
+}: WriteCasFileOptions): Promise<void> => {
+  if (isEmpty(jwt)) {
+    throw new CaClientError("jwt must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  const dest = casFilePath({ fileName, outputDir, baseDir });
+  const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
+
+  try {
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, casContent, "utf8");
+  } catch (error) {
+    throw toFileError(`Failed to write CAS file ${dest}`, error);
+  }
+};
+
+export const deleteCasFiles = async (
+  fileNames: string[],
+  { outputDir, baseDir }: CasDirOptions,
+): Promise<void> => {
+  if (fileNames.length === 0) {
+    return;
+  }
+
+  const dir = resolveCasDir({ outputDir, baseDir });
+
+  await Promise.all(
+    fileNames.map((fileName) => {
+      if (isEmpty(fileName)) {
+        throw new CaClientError("fileName must be a non-empty string", {
+          code: CaClientErrorCode.Validation,
+        });
+      }
+      return unlinkMissing(join(dir, fileName));
+    }),
+  );
+};

--- a/packages/ca-client/src/errors.ts
+++ b/packages/ca-client/src/errors.ts
@@ -4,6 +4,7 @@ export const CaClientErrorCode = {
   Validation: "CA_VALIDATION",
   Http: "CA_HTTP",
   Response: "CA_RESPONSE",
+  File: "CA_FILE",
 } as const;
 
 export type CaClientErrorCode =

--- a/packages/ca-client/src/index.test.ts
+++ b/packages/ca-client/src/index.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest";
 import * as publicApi from "./index";
 
-test("public API: exports createCaClient and error types", () => {
+test("public API: exports createCaClient, writeCasFile, and error types", () => {
   expect(typeof publicApi.createCaClient).toBe("function");
+  expect(typeof publicApi.writeCasFile).toBe("function");
   expect(typeof publicApi.isUnauthorized).toBe("function");
   expect(publicApi.CaClientError).toBeDefined();
   expect(Object.keys(publicApi).sort()).toEqual([
@@ -10,6 +11,7 @@ test("public API: exports createCaClient and error types", () => {
     "CaClientErrorCode",
     "createCaClient",
     "isUnauthorized",
+    "writeCasFile",
   ]);
 });
 
@@ -20,4 +22,7 @@ test("public API: does not export low-level APIs from index", () => {
   expect(api.TokenManager).toBeUndefined();
   expect(api.serverSignOptions).toBeUndefined();
   expect(api.signByCaServer).toBeUndefined();
+  expect(api.deleteCasFiles).toBeUndefined();
+  expect(api.resolveCasDir).toBeUndefined();
+  expect(api.casFilePath).toBeUndefined();
 });

--- a/packages/ca-client/src/index.test.ts
+++ b/packages/ca-client/src/index.test.ts
@@ -23,6 +23,5 @@ test("public API: does not export low-level APIs from index", () => {
   expect(api.serverSignOptions).toBeUndefined();
   expect(api.signByCaServer).toBeUndefined();
   expect(api.deleteCasFiles).toBeUndefined();
-  expect(api.resolveCasDir).toBeUndefined();
-  expect(api.casFilePath).toBeUndefined();
+  expect(api.resolveCasFilePath).toBeUndefined();
 });

--- a/packages/ca-client/src/index.ts
+++ b/packages/ca-client/src/index.ts
@@ -3,4 +3,5 @@ export {
   type CaClient,
   type CaClientConfig,
 } from "./ca-client/create-ca-client";
+export { writeCasFile, type WriteCasFileOptions } from "./cas-store/file";
 export { CaClientError, CaClientErrorCode, isUnauthorized } from "./errors";


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)
cas-clientに `writeCasFile` メソッドを追加しました。
`@originator-profile/ca-client` の Public API として `writeCasFile` を追加しました。
署名済み JWT をCAS ファイルとして書き出し、サイト実装ごとのファイル形式のばらつきを防ぎます。

README に利用例が書いてあるので、インターフェースはそこを参照ください。

利用側のイメージ
```ts
const jwt = await client.sign(unsignedCa);

// output dist/cas/ja-JP.hello.cas.json
await writeCasFile({
  fileName: "ja-JP.hello.cas.json",
  jwt,
  outputDir: "dist/cas",
});
```

close #468 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
別途Publishして、OPサイトで動作確認予定です。
