### PR TITLE
feat(ca-client): detectDriftを公開する

### DIFF
--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -44,6 +44,7 @@ $ pnpm add @originator-profile/ca-client
 import {
   createCaClient,
   writeCasFile,
+  detectDrift,
   CaClientError,
   CaClientErrorCode,
   isUnauthorized,
@@ -195,6 +196,52 @@ try {
 
 > [!NOTE]
 > CCSP の 401 は `CA_AUTH` であり、`isUnauthorized` の判定には含まれません。
+
+### HTML と CAS の drift 検出
+
+`detectDrift` はビルド後 HTML から target integrity を再計算し、CAS に記録された target とのずれを判定します。発行パイプライン向けです。
+
+[`@originator-profile/verify`](https://www.npmjs.com/package/@originator-profile/verify) とは責務が違います。`verify` は閲覧時の暗号検証（JWT 署名・integrity の真正性）です。`detectDrift` は署名を検証せず、記録済み target と現 HTML の差分だけを見ます。
+
+```ts
+const result = await detectDrift(builtHtml, "public/cas/ja-JP.page.cas.json");
+
+switch (result.status) {
+  case "ok":
+    break;
+  case "cas_missing":
+    // CAS ファイルが無い → 新規署名
+    break;
+  case "cas_invalid":
+    console.warn(result.reason);
+    break;
+  case "html_no_targets":
+    // セレクタに一致する要素が HTML に無い
+    break;
+  case "drifted":
+    // result.current / result.expected で差分を確認
+    break;
+}
+```
+
+| `status`          | 意味                                               |
+| ----------------- | -------------------------------------------------- |
+| `ok`              | HTML から再計算した target が CAS と一致する       |
+| `cas_missing`     | CAS ファイルが存在しない                           |
+| `cas_invalid`     | CAS の JSON / JWT が不正                           |
+| `html_no_targets` | HTML から target を抽出できない                    |
+| `drifted`         | target がずれている（`current` / `expected` 付き） |
+
+TextTargetIntegrity / HtmlTargetIntegrity / VisibleTextTargetIntegrity の `cssSelector` は CAS に記録された値を使い、同じセレクタで HTML を再評価します。CAS にセレクタが無いときだけ、第 3 引数で渡せます。
+
+```ts
+await detectDrift(html, casPath, {
+  textSelector: "main",
+  externalSelector: ".op-resource",
+});
+```
+
+CIP サイト前提の既定セレクタ（`article [itemprop='headline']` 等）は使いません。ExternalResourceTargetIntegrity は CAS の `cssSelector`、引数の `externalSelector`、どちらも無ければ `.target-integrity` で HTML 上の `integrity` 属性を集めます。
 
 ## ライセンス
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -145,15 +145,14 @@ const renewed = await client.reSign(
 await writeCasFile({
   fileName: "ja-JP.page.cas.json",
   jwt,
-  outputDir: "dist/cas",
+  outputDir: "./dist/cas",
 });
 
 // output /path/to/site/dist/cas/ja-JP.page.cas.json
 await writeCasFile({
   fileName: "ja-JP.page.cas.json",
   jwt,
-  outputDir: "dist/cas",
-  baseDir: "/path/to/site",
+  outputDir: "/path/to/site/dist/cas",
 });
 ```
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -123,7 +123,7 @@ const jwt = await client.sign({
 });
 ```
 
-### resign
+### reSign
 
 `reSign` メソッドは、既存 CAS の JWT payload を再署名し、JWT 文字列を返します。第 2 引数 `source` はエラーメッセージの文脈（CAS ファイルパスなど）に使われます。
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -43,6 +43,7 @@ $ pnpm add @originator-profile/ca-client
 ```ts
 import {
   createCaClient,
+  writeCasFile,
   CaClientError,
   CaClientErrorCode,
   isUnauthorized,
@@ -74,6 +75,21 @@ const client = createCaClient({
 > [!NOTE]
 > `authType` は `client_secret_post` のみ対応しています。`clientSec` は OAuth の `client_secret` です。
 
+### Quick Start
+
+未署名 CA を CA サーバーで署名し、署名済み JWT を CAS ファイルとして書き出します。
+
+```ts
+const jwt = await client.sign(unsignedCa);
+
+// output dist/cas/ja-JP.hello.cas.json
+await writeCasFile({
+  fileName: "ja-JP.hello.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+});
+```
+
 ### APIメソッド
 
 | メソッド | 説明                                 |
@@ -81,7 +97,7 @@ const client = createCaClient({
 | `sign`   | 未署名 CA を CA サーバーで署名する   |
 | `reSign` | 既存 CAS の JWT payload を再署名する |
 
-### 未署名 CA の署名
+### sign
 
 `sign` メソッドは、未署名の Content Attestation を CA サーバーで署名し、JWT 文字列を返します。
 
@@ -107,7 +123,7 @@ const jwt = await client.sign({
 });
 ```
 
-### 既存 CAS の再署名
+### resign
 
 `reSign` メソッドは、既存 CAS の JWT payload を再署名し、JWT 文字列を返します。第 2 引数 `source` はエラーメッセージの文脈（CAS ファイルパスなど）に使われます。
 
@@ -119,6 +135,27 @@ const renewed = await client.reSign(
 ```
 
 `createCaClient` に渡した `issuer` が、payload の `issuer` より優先されます。
+
+### writeCasFile
+
+`writeCasFile` は、署名済み JWT を CAS ファイルとして書き出します。`fileName`・`jwt`・`outputDir` は必須です。
+
+```ts
+// output dist/cas/ja-JP.page.cas.json
+await writeCasFile({
+  fileName: "ja-JP.page.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+});
+
+// output /path/to/site/dist/cas/ja-JP.page.cas.json
+await writeCasFile({
+  fileName: "ja-JP.page.cas.json",
+  jwt,
+  outputDir: "dist/cas",
+  baseDir: "/path/to/site",
+});
+```
 
 ### エラー
 
@@ -139,9 +176,10 @@ try {
 | --------------- | ---------------------------------------------------- |
 | `CA_CONFIG`     | CCSP 設定の欠落・不正、未対応の `authType`           |
 | `CA_AUTH`       | CCSP トークンエンドポイントの失敗（401 を含む）      |
-| `CA_VALIDATION` | 未署名 CA・CAS payload・日付の不正                   |
+| `CA_VALIDATION` | 未署名 CA・CAS payload・日付・パス・JWT の不正       |
 | `CA_HTTP`       | CA サーバーが非 2xx を返した、またはネットワーク障害 |
 | `CA_RESPONSE`   | CA サーバーの本文が空、または JWT を含まない         |
+| `CA_FILE`       | CAS ファイルの書き込み・削除に失敗した               |
 
 `sign()` / `reSign()` は CA サーバーが 401 を返したとき、アクセストークンを更新して 1 回だけ再試行します。再試行後も 401 なら `isUnauthorized(error)` が真になります。
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -78,7 +78,7 @@ const client = createCaClient({
 
 ### Quick Start
 
-未署名 CA を CA サーバーで署名し、署名済み JWT を CAS ファイルとして書き出します。
+未署名 CA を CA サーバーで署名し、CAS ファイルとして書き出したうえで、HTML との drift を判定します。
 
 ```ts
 const jwt = await client.sign(unsignedCa);
@@ -87,6 +87,12 @@ const jwt = await client.sign(unsignedCa);
 await writeCasFile({
   fileName: "ja-JP.hello.cas.json",
   jwt,
+  outputDir: "dist/cas",
+});
+
+const result = await detectDrift({
+  html: builtHtml,
+  fileName: "ja-JP.hello.cas.json",
   outputDir: "dist/cas",
 });
 ```
@@ -157,6 +163,57 @@ await writeCasFile({
 });
 ```
 
+### detectDrift
+
+`detectDrift` は、ビルド後 HTML から target integrity を再計算し、CAS に記録された target とのずれを判定します。`html`・`fileName`・`outputDir` は必須です。
+
+[`@originator-profile/verify`](https://www.npmjs.com/package/@originator-profile/verify) による暗号検証（JWT 署名の真正性）とは別です。署名は検証せず、記録済み target と現 HTML の差分だけを見ます。
+
+```ts
+const result = await detectDrift({
+  html: builtHtml,
+  fileName: "ja-JP.page.cas.json",
+  outputDir: "./dist/cas",
+});
+
+switch (result.status) {
+  case "ok":
+    break;
+  case "cas_missing":
+    // CAS ファイルが無い → 新規署名
+    break;
+  case "cas_invalid":
+    console.warn(result.reason);
+    break;
+  case "html_no_targets":
+    // セレクタに一致する要素が HTML に無い
+    break;
+  case "drifted":
+    // result.current / result.expected で差分を確認
+    break;
+}
+```
+
+| `status`          | 意味                                               |
+| ----------------- | -------------------------------------------------- |
+| `ok`              | HTML から再計算した target が CAS と一致する       |
+| `cas_missing`     | CAS ファイルが存在しない                           |
+| `cas_invalid`     | CAS の JSON / JWT が不正                           |
+| `html_no_targets` | HTML から target を抽出できない                    |
+| `drifted`         | target がずれている（`current` / `expected` 付き） |
+
+TextTargetIntegrity などの `cssSelector` は CAS に記録された値を使い、同じセレクタで HTML を再評価します。CAS にセレクタが無いときだけ、オプションで渡せます。
+
+```ts
+await detectDrift({
+  html: builtHtml,
+  fileName: "ja-JP.page.cas.json",
+  outputDir: "./dist/cas",
+  textSelector: "main",
+  externalSelector: ".op-resource",
+});
+```
+
 ### エラー
 
 失敗時はすべて `CaClientError` を throw します。`code` で種別を、HTTP 失敗では `status` でステータスを判定してください。
@@ -196,52 +253,6 @@ try {
 
 > [!NOTE]
 > CCSP の 401 は `CA_AUTH` であり、`isUnauthorized` の判定には含まれません。
-
-### HTML と CAS の drift 検出
-
-`detectDrift` はビルド後 HTML から target integrity を再計算し、CAS に記録された target とのずれを判定します。発行パイプライン向けです。
-
-[`@originator-profile/verify`](https://www.npmjs.com/package/@originator-profile/verify) とは責務が違います。`verify` は閲覧時の暗号検証（JWT 署名・integrity の真正性）です。`detectDrift` は署名を検証せず、記録済み target と現 HTML の差分だけを見ます。
-
-```ts
-const result = await detectDrift(builtHtml, "public/cas/ja-JP.page.cas.json");
-
-switch (result.status) {
-  case "ok":
-    break;
-  case "cas_missing":
-    // CAS ファイルが無い → 新規署名
-    break;
-  case "cas_invalid":
-    console.warn(result.reason);
-    break;
-  case "html_no_targets":
-    // セレクタに一致する要素が HTML に無い
-    break;
-  case "drifted":
-    // result.current / result.expected で差分を確認
-    break;
-}
-```
-
-| `status`          | 意味                                               |
-| ----------------- | -------------------------------------------------- |
-| `ok`              | HTML から再計算した target が CAS と一致する       |
-| `cas_missing`     | CAS ファイルが存在しない                           |
-| `cas_invalid`     | CAS の JSON / JWT が不正                           |
-| `html_no_targets` | HTML から target を抽出できない                    |
-| `drifted`         | target がずれている（`current` / `expected` 付き） |
-
-TextTargetIntegrity / HtmlTargetIntegrity / VisibleTextTargetIntegrity の `cssSelector` は CAS に記録された値を使い、同じセレクタで HTML を再評価します。CAS にセレクタが無いときだけ、第 3 引数で渡せます。
-
-```ts
-await detectDrift(html, casPath, {
-  textSelector: "main",
-  externalSelector: ".op-resource",
-});
-```
-
-CIP サイト前提の既定セレクタ（`article [itemprop='headline']` 等）は使いません。ExternalResourceTargetIntegrity は CAS の `cssSelector`、引数の `externalSelector`、どちらも無ければ `.target-integrity` で HTML 上の `integrity` 属性を集めます。
 
 ## ライセンス
 

--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -78,7 +78,7 @@ const client = createCaClient({
 
 ### Quick Start
 
-未署名 CA を CA サーバーで署名し、CAS ファイルとして書き出したうえで、HTML との drift を判定します。
+未署名 CA を CA サーバーで署名し、CAS ファイルとして書き出します。
 
 ```ts
 const jwt = await client.sign(unsignedCa);
@@ -87,12 +87,6 @@ const jwt = await client.sign(unsignedCa);
 await writeCasFile({
   fileName: "ja-JP.hello.cas.json",
   jwt,
-  outputDir: "dist/cas",
-});
-
-const result = await detectDrift({
-  html: builtHtml,
-  fileName: "ja-JP.hello.cas.json",
   outputDir: "dist/cas",
 });
 ```
@@ -166,8 +160,6 @@ await writeCasFile({
 ### detectDrift
 
 `detectDrift` は、ビルド後 HTML から target integrity を再計算し、CAS に記録された target とのずれを判定します。`html`・`fileName`・`outputDir` は必須です。
-
-[`@originator-profile/verify`](https://www.npmjs.com/package/@originator-profile/verify) による暗号検証（JWT 署名の真正性）とは別です。署名は検証せず、記録済み target と現 HTML の差分だけを見ます。
 
 ```ts
 const result = await detectDrift({

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,0 +1,218 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { expect, test } from "vitest";
+import { CaClientError, CaClientErrorCode } from "../errors";
+import { deleteCasFiles, resolveCasDir, writeCasFile } from "./file";
+
+const withTempDir = async (run: (dir: string) => Promise<void>) => {
+  const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+};
+
+test("writeCasFile: writes JWT as a one-element JSON array with a trailing newline", async () => {
+  await withTempDir(async (dir) => {
+    const jwt = "test-jwt-token";
+
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt,
+      outputDir: "cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(join(dir, "cas", "test.cas.json"), "utf8");
+    expect(written).toBe(`${JSON.stringify([jwt], null, 2)}\n`);
+  });
+});
+
+test("writeCasFile: creates nested directories from outputDir and fileName", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "nested/page.cas.json",
+      jwt: "jwt-1",
+      outputDir: "out/cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(
+      join(dir, "out", "cas", "nested", "page.cas.json"),
+      "utf8",
+    );
+    expect(JSON.parse(written)).toEqual(["jwt-1"]);
+  });
+});
+
+test("writeCasFile: resolves relative outputDir against the baseDir option", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "a.cas.json",
+      jwt: "jwt-a",
+      outputDir: "relative/cas",
+      baseDir: dir,
+    });
+
+    const written = await readFile(
+      join(dir, "relative", "cas", "a.cas.json"),
+      "utf8",
+    );
+    expect(JSON.parse(written)).toEqual(["jwt-a"]);
+  });
+});
+
+test("writeCasFile: uses an absolute outputDir as-is", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "absolute", "cas");
+
+    await writeCasFile({
+      fileName: "b.cas.json",
+      jwt: "jwt-b",
+      outputDir,
+      baseDir: "/unused",
+    });
+
+    const written = await readFile(join(outputDir, "b.cas.json"), "utf8");
+    expect(JSON.parse(written)).toEqual(["jwt-b"]);
+  });
+});
+
+test("writeCasFile: rejects an empty outputDir", async () => {
+  await expect(
+    writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir: "" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "outputDir must be a non-empty string",
+  });
+});
+
+test("writeCasFile: rejects an empty fileName", async () => {
+  await expect(
+    writeCasFile({ fileName: "", jwt: "jwt", outputDir: "cas" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "fileName must be a non-empty string",
+  });
+});
+
+test("writeCasFile: rejects an empty jwt", async () => {
+  await expect(
+    writeCasFile({ fileName: "a.cas.json", jwt: "", outputDir: "cas" }),
+  ).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "jwt must be a non-empty string",
+  });
+});
+
+test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
+  await withTempDir(async (dir) => {
+    const blocker = join(dir, "not-a-dir");
+    await writeFile(blocker, "file");
+
+    await expect(
+      writeCasFile({
+        fileName: "a.cas.json",
+        jwt: "jwt",
+        outputDir: join(blocker, "cas"),
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.File,
+    });
+  });
+});
+
+test("deleteCasFiles: deletes existing CAS files", async () => {
+  await withTempDir(async (dir) => {
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir: "cas",
+      baseDir: dir,
+    });
+    await writeCasFile({
+      fileName: "drop.cas.json",
+      jwt: "drop",
+      outputDir: "cas",
+      baseDir: dir,
+    });
+
+    await deleteCasFiles(["drop.cas.json"], { outputDir: "cas", baseDir: dir });
+
+    const kept = await readFile(join(dir, "cas", "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+    await expect(
+      readFile(join(dir, "cas", "drop.cas.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+test("deleteCasFiles: skips missing files", async () => {
+  await withTempDir(async (dir) => {
+    await mkdir(join(dir, "cas"), { recursive: true });
+
+    await expect(
+      deleteCasFiles(["missing.cas.json"], { outputDir: "cas", baseDir: dir }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+test("deleteCasFiles: does nothing for an empty list", async () => {
+  await expect(deleteCasFiles([], { outputDir: "" })).resolves.toBeUndefined();
+});
+
+test("deleteCasFiles: deletes multiple CAS files", async () => {
+  await withTempDir(async (dir) => {
+    const names = ["one.cas.json", "two.cas.json"];
+    await Promise.all(
+      names.map((fileName) =>
+        writeCasFile({
+          fileName,
+          jwt: fileName,
+          outputDir: "cas",
+          baseDir: dir,
+        }),
+      ),
+    );
+
+    await deleteCasFiles(names, { outputDir: "cas", baseDir: dir });
+
+    await Promise.all(
+      names.map((name) =>
+        expect(readFile(join(dir, "cas", name), "utf8")).rejects.toMatchObject({
+          code: "ENOENT",
+        }),
+      ),
+    );
+  });
+});
+
+test("resolveCasDir: resolves a relative path against baseDir", () => {
+  const dir = resolveCasDir({ outputDir: "public/cas", baseDir: "/workspace" });
+  expect(dir).toBe(resolve("/workspace", "public", "cas"));
+});
+
+test("resolveCasDir: defaults to process.cwd() for relative paths", () => {
+  expect(resolveCasDir({ outputDir: "public/cas" })).toBe(
+    resolve(process.cwd(), "public", "cas"),
+  );
+});
+
+test("resolveCasDir: returns an absolute path unchanged", () => {
+  expect(resolveCasDir({ outputDir: "/abs/cas", baseDir: "/workspace" })).toBe(
+    resolve("/abs/cas"),
+  );
+});
+
+test("resolveCasDir: rejects an empty path so it is not resolved to the root", () => {
+  expect(() => resolveCasDir({ outputDir: "" })).toThrow(CaClientError);
+  expect(() => resolveCasDir({ outputDir: "" })).toThrow(
+    "outputDir must be a non-empty string",
+  );
+});

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -154,7 +154,7 @@ test("writeCasFile: replaces an existing file with complete new content", async 
   });
 });
 
-test("writeCasFile: removes the temp file when rename cannot replace dest", async () => {
+test("writeCasFile: wraps EISDIR when dest is a directory", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "cas");
     await mkdir(join(outputDir, "test.cas.json"), { recursive: true });

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -60,7 +60,7 @@ test("writeCasFile: creates nested directories from outputDir and fileName", asy
   });
 });
 
-test("writeCasFile: uses an absolute outputDir as-is", async () => {
+test("writeCasFile: writes to a deeply nested absolute outputDir", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "absolute", "cas");
 

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -70,27 +70,31 @@ test("writeCasFile: writes when outputDir already exists", async () => {
 });
 
 test("writeCasFile: rejects an empty outputDir", async () => {
-  for (const outputDir of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((outputDir) =>
+      expect(
+        writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: rejects an empty fileName", async () => {
-  for (const fileName of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "fileName must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((fileName) =>
+      expect(
+        writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "fileName must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
@@ -114,15 +118,17 @@ test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
 });
 
 test("writeCasFile: rejects an empty jwt", async () => {
-  for (const jwt of ["", "   "]) {
-    await expect(
-      writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "jwt must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map((jwt) =>
+      expect(
+        writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "jwt must be a non-empty string",
+      }),
+    ),
+  );
 });
 
 test("writeCasFile: replaces an existing file with complete new content", async () => {
@@ -224,20 +230,22 @@ test("deleteCasFiles: does nothing for an empty list", async () => {
 });
 
 test("deleteCasFiles: rejects an empty outputDir even for an empty list", async () => {
-  for (const outputDir of ["", "   "]) {
-    await expect(
-      deleteCasFiles(["a.cas.json"], outputDir),
-    ).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-    await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
-      name: "CaClientError",
-      code: CaClientErrorCode.Validation,
-      message: "outputDir must be a non-empty string",
-    });
-  }
+  await Promise.all(
+    ["", "   "].map(async (outputDir) => {
+      await expect(
+        deleteCasFiles(["a.cas.json"], outputDir),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      });
+      await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      });
+    }),
+  );
 });
 
 test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,11 +1,4 @@
-import {
-  mkdir,
-  mkdtemp,
-  readdir,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
@@ -60,9 +53,10 @@ test("writeCasFile: creates nested directories from outputDir and fileName", asy
   });
 });
 
-test("writeCasFile: writes to a deeply nested absolute outputDir", async () => {
+test("writeCasFile: writes when outputDir already exists", async () => {
   await withTempDir(async (dir) => {
-    const outputDir = join(dir, "absolute", "cas");
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
 
     await writeCasFile({
       fileName: "b.cas.json",
@@ -148,9 +142,6 @@ test("writeCasFile: replaces an existing file with complete new content", async 
 
     const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
     expect(written).toBe(`${JSON.stringify(["new-jwt"], null, 2)}\n`);
-    expect(
-      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
-    ).toEqual([]);
   });
 });
 
@@ -169,10 +160,6 @@ test("writeCasFile: wraps EISDIR when dest is a directory", async () => {
       name: "CaClientError",
       code: CaClientErrorCode.File,
     });
-
-    expect(
-      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
-    ).toEqual([]);
   });
 });
 

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -1,4 +1,11 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
@@ -124,6 +131,51 @@ test("writeCasFile: rejects an empty jwt", async () => {
   }
 });
 
+test("writeCasFile: replaces an existing file with complete new content", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt: "old-jwt",
+      outputDir,
+    });
+    await writeCasFile({
+      fileName: "test.cas.json",
+      jwt: "new-jwt",
+      outputDir,
+    });
+
+    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
+    expect(written).toBe(`${JSON.stringify(["new-jwt"], null, 2)}\n`);
+    expect(
+      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+  });
+});
+
+test("writeCasFile: removes the temp file when rename cannot replace dest", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await mkdir(join(outputDir, "test.cas.json"), { recursive: true });
+
+    await expect(
+      writeCasFile({
+        fileName: "test.cas.json",
+        jwt: "jwt",
+        outputDir,
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.File,
+    });
+
+    expect(
+      (await readdir(outputDir)).filter((name) => name.endsWith(".tmp")),
+    ).toEqual([]);
+  });
+});
+
 test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
   await withTempDir(async (dir) => {
     const blocker = join(dir, "not-a-dir");
@@ -179,7 +231,26 @@ test("deleteCasFiles: skips missing files", async () => {
 });
 
 test("deleteCasFiles: does nothing for an empty list", async () => {
-  await expect(deleteCasFiles([], "")).resolves.toBeUndefined();
+  await withTempDir(async (dir) => {
+    await expect(deleteCasFiles([], join(dir, "cas"))).resolves.toBeUndefined();
+  });
+});
+
+test("deleteCasFiles: rejects an empty outputDir even for an empty list", async () => {
+  for (const outputDir of ["", "   "]) {
+    await expect(
+      deleteCasFiles(["a.cas.json"], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+    await expect(deleteCasFiles([], outputDir)).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+  }
 });
 
 test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 import { CaClientError, CaClientErrorCode } from "../errors";
-import { deleteCasFiles, resolveCasDir, writeCasFile } from "./file";
+import {
+  casFilePath,
+  deleteCasFiles,
+  resolveCasDir,
+  writeCasFile,
+} from "./file";
 
 const withTempDir = async (run: (dir: string) => Promise<void>) => {
   const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
@@ -17,50 +22,34 @@ const withTempDir = async (run: (dir: string) => Promise<void>) => {
 test("writeCasFile: writes JWT as a one-element JSON array with a trailing newline", async () => {
   await withTempDir(async (dir) => {
     const jwt = "test-jwt-token";
+    const outputDir = join(dir, "cas");
 
     await writeCasFile({
       fileName: "test.cas.json",
       jwt,
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
 
-    const written = await readFile(join(dir, "cas", "test.cas.json"), "utf8");
+    const written = await readFile(join(outputDir, "test.cas.json"), "utf8");
     expect(written).toBe(`${JSON.stringify([jwt], null, 2)}\n`);
   });
 });
 
 test("writeCasFile: creates nested directories from outputDir and fileName", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "out", "cas");
+
     await writeCasFile({
       fileName: "nested/page.cas.json",
       jwt: "jwt-1",
-      outputDir: "out/cas",
-      baseDir: dir,
+      outputDir,
     });
 
     const written = await readFile(
-      join(dir, "out", "cas", "nested", "page.cas.json"),
+      join(outputDir, "nested", "page.cas.json"),
       "utf8",
     );
     expect(JSON.parse(written)).toEqual(["jwt-1"]);
-  });
-});
-
-test("writeCasFile: resolves relative outputDir against the baseDir option", async () => {
-  await withTempDir(async (dir) => {
-    await writeCasFile({
-      fileName: "a.cas.json",
-      jwt: "jwt-a",
-      outputDir: "relative/cas",
-      baseDir: dir,
-    });
-
-    const written = await readFile(
-      join(dir, "relative", "cas", "a.cas.json"),
-      "utf8",
-    );
-    expect(JSON.parse(written)).toEqual(["jwt-a"]);
   });
 });
 
@@ -72,7 +61,6 @@ test("writeCasFile: uses an absolute outputDir as-is", async () => {
       fileName: "b.cas.json",
       jwt: "jwt-b",
       outputDir,
-      baseDir: "/unused",
     });
 
     const written = await readFile(join(outputDir, "b.cas.json"), "utf8");
@@ -81,33 +69,59 @@ test("writeCasFile: uses an absolute outputDir as-is", async () => {
 });
 
 test("writeCasFile: rejects an empty outputDir", async () => {
-  await expect(
-    writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir: "" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "outputDir must be a non-empty string",
-  });
+  for (const outputDir of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName: "a.cas.json", jwt: "jwt", outputDir }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "outputDir must be a non-empty string",
+    });
+  }
 });
 
 test("writeCasFile: rejects an empty fileName", async () => {
-  await expect(
-    writeCasFile({ fileName: "", jwt: "jwt", outputDir: "cas" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "fileName must be a non-empty string",
+  for (const fileName of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName, jwt: "jwt", outputDir: "cas" }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+  }
+});
+
+test("writeCasFile: rejects a fileName that escapes outputDir", async () => {
+  await withTempDir(async (dir) => {
+    await expect(
+      writeCasFile({
+        fileName: "../outside.cas.json",
+        jwt: "jwt",
+        outputDir: join(dir, "cas"),
+      }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must stay inside outputDir",
+    });
+
+    await expect(
+      readFile(join(dir, "outside.cas.json"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 
 test("writeCasFile: rejects an empty jwt", async () => {
-  await expect(
-    writeCasFile({ fileName: "a.cas.json", jwt: "", outputDir: "cas" }),
-  ).rejects.toMatchObject({
-    name: "CaClientError",
-    code: CaClientErrorCode.Validation,
-    message: "jwt must be a non-empty string",
-  });
+  for (const jwt of ["", "   "]) {
+    await expect(
+      writeCasFile({ fileName: "a.cas.json", jwt, outputDir: "cas" }),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "jwt must be a non-empty string",
+    });
+  }
 });
 
 test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
@@ -130,62 +144,119 @@ test("writeCasFile: wraps filesystem failures as CA_FILE", async () => {
 
 test("deleteCasFiles: deletes existing CAS files", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
     await writeCasFile({
       fileName: "keep.cas.json",
       jwt: "keep",
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
     await writeCasFile({
       fileName: "drop.cas.json",
       jwt: "drop",
-      outputDir: "cas",
-      baseDir: dir,
+      outputDir,
     });
 
-    await deleteCasFiles(["drop.cas.json"], { outputDir: "cas", baseDir: dir });
+    await deleteCasFiles(["drop.cas.json"], outputDir);
 
-    const kept = await readFile(join(dir, "cas", "keep.cas.json"), "utf8");
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
     expect(JSON.parse(kept)).toEqual(["keep"]);
     await expect(
-      readFile(join(dir, "cas", "drop.cas.json"), "utf8"),
+      readFile(join(outputDir, "drop.cas.json"), "utf8"),
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });
 
 test("deleteCasFiles: skips missing files", async () => {
   await withTempDir(async (dir) => {
-    await mkdir(join(dir, "cas"), { recursive: true });
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
 
     await expect(
-      deleteCasFiles(["missing.cas.json"], { outputDir: "cas", baseDir: dir }),
+      deleteCasFiles(["missing.cas.json"], outputDir),
     ).resolves.toBeUndefined();
   });
 });
 
 test("deleteCasFiles: does nothing for an empty list", async () => {
-  await expect(deleteCasFiles([], { outputDir: "" })).resolves.toBeUndefined();
+  await expect(deleteCasFiles([], "")).resolves.toBeUndefined();
+});
+
+test("deleteCasFiles: rejects a fileName that escapes outputDir before deleting any files", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir,
+    });
+    const outside = join(dir, "outside.cas.json");
+    await writeFile(outside, "secret");
+
+    await expect(
+      deleteCasFiles(["keep.cas.json", "../outside.cas.json"], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must stay inside outputDir",
+    });
+
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+    expect(await readFile(outside, "utf8")).toBe("secret");
+  });
+});
+
+test("deleteCasFiles: rejects an empty fileName before deleting any files", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+
+    await writeCasFile({
+      fileName: "keep.cas.json",
+      jwt: "keep",
+      outputDir,
+    });
+
+    await expect(
+      deleteCasFiles(["keep.cas.json", ""], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+    await expect(
+      deleteCasFiles(["keep.cas.json", "   "], outputDir),
+    ).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "fileName must be a non-empty string",
+    });
+
+    const kept = await readFile(join(outputDir, "keep.cas.json"), "utf8");
+    expect(JSON.parse(kept)).toEqual(["keep"]);
+  });
 });
 
 test("deleteCasFiles: deletes multiple CAS files", async () => {
   await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
     const names = ["one.cas.json", "two.cas.json"];
     await Promise.all(
       names.map((fileName) =>
         writeCasFile({
           fileName,
           jwt: fileName,
-          outputDir: "cas",
-          baseDir: dir,
+          outputDir,
         }),
       ),
     );
 
-    await deleteCasFiles(names, { outputDir: "cas", baseDir: dir });
+    await deleteCasFiles(names, outputDir);
 
     await Promise.all(
       names.map((name) =>
-        expect(readFile(join(dir, "cas", name), "utf8")).rejects.toMatchObject({
+        expect(readFile(join(outputDir, name), "utf8")).rejects.toMatchObject({
           code: "ENOENT",
         }),
       ),
@@ -193,26 +264,66 @@ test("deleteCasFiles: deletes multiple CAS files", async () => {
   });
 });
 
-test("resolveCasDir: resolves a relative path against baseDir", () => {
-  const dir = resolveCasDir({ outputDir: "public/cas", baseDir: "/workspace" });
-  expect(dir).toBe(resolve("/workspace", "public", "cas"));
+test("casFilePath: keeps nested fileName inside outputDir", () => {
+  expect(
+    casFilePath({
+      fileName: "nested/page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "nested", "page.cas.json"));
 });
 
-test("resolveCasDir: defaults to process.cwd() for relative paths", () => {
-  expect(resolveCasDir({ outputDir: "public/cas" })).toBe(
+test("casFilePath: allows a fileName whose .. segments stay inside outputDir", () => {
+  expect(
+    casFilePath({
+      fileName: "nested/../page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "page.cas.json"));
+});
+
+test("casFilePath: rejects a fileName that escapes outputDir", () => {
+  for (const fileName of [
+    "../outside.cas.json",
+    "../../etc/passwd",
+    "nested/../../outside.cas.json",
+    "/etc/passwd",
+    ".",
+    "..",
+  ]) {
+    expect(() =>
+      casFilePath({ fileName, outputDir: "/workspace/cas" }),
+    ).toThrow("fileName must stay inside outputDir");
+  }
+});
+
+test("casFilePath: does not treat a name starting with .. as traversal", () => {
+  expect(
+    casFilePath({
+      fileName: "..page.cas.json",
+      outputDir: "/workspace/cas",
+    }),
+  ).toBe(resolve("/workspace", "cas", "..page.cas.json"));
+});
+
+test("resolveCasDir: resolves a relative path against process.cwd()", () => {
+  expect(resolveCasDir("public/cas")).toBe(
+    resolve(process.cwd(), "public", "cas"),
+  );
+  expect(resolveCasDir("./public/cas")).toBe(
     resolve(process.cwd(), "public", "cas"),
   );
 });
 
 test("resolveCasDir: returns an absolute path unchanged", () => {
-  expect(resolveCasDir({ outputDir: "/abs/cas", baseDir: "/workspace" })).toBe(
-    resolve("/abs/cas"),
-  );
+  expect(resolveCasDir("/abs/cas")).toBe(resolve("/abs/cas"));
 });
 
 test("resolveCasDir: rejects an empty path so it is not resolved to the root", () => {
-  expect(() => resolveCasDir({ outputDir: "" })).toThrow(CaClientError);
-  expect(() => resolveCasDir({ outputDir: "" })).toThrow(
-    "outputDir must be a non-empty string",
-  );
+  for (const outputDir of ["", "   "]) {
+    expect(() => resolveCasDir(outputDir)).toThrow(CaClientError);
+    expect(() => resolveCasDir(outputDir)).toThrow(
+      "outputDir must be a non-empty string",
+    );
+  }
 });

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
@@ -90,16 +89,11 @@ export const writeCasFile = async ({
   }
   const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
-  // Same-directory temp + rename so dest is never a truncated JWT CAS file
-  // if the process is killed or the disk fills mid-write.
-  const tmp = `${dest}.${randomUUID()}.tmp`;
 
   try {
     await mkdir(dirname(dest), { recursive: true });
-    await writeFile(tmp, casContent, "utf8");
-    await rename(tmp, dest);
+    await writeFile(dest, casContent, "utf8");
   } catch (error) {
-    await unlink(tmp).catch(() => {});
     throw toFileError(`Failed to write CAS file ${dest}`, error);
   }
 };

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,4 +1,5 @@
-import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
@@ -89,11 +90,16 @@ export const writeCasFile = async ({
   }
   const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
+  // Same-directory temp + rename so dest is never a truncated JWT CAS file
+  // if the process is killed or the disk fills mid-write.
+  const tmp = `${dest}.${randomUUID()}.tmp`;
 
   try {
     await mkdir(dirname(dest), { recursive: true });
-    await writeFile(dest, casContent, "utf8");
+    await writeFile(tmp, casContent, "utf8");
+    await rename(tmp, dest);
   } catch (error) {
+    await unlink(tmp).catch(() => {});
     throw toFileError(`Failed to write CAS file ${dest}`, error);
   }
 };
@@ -102,12 +108,13 @@ export const deleteCasFiles = async (
   fileNames: string[],
   outputDir: string,
 ): Promise<void> => {
+  const dir = resolveCasDir(outputDir);
   if (fileNames.length === 0) {
     return;
   }
 
   const dests = fileNames.map((fileName) =>
-    casFilePath({ fileName, outputDir }),
+    casFilePath({ fileName, outputDir: dir }),
   );
 
   await Promise.all(dests.map((filePath) => unlinkMissing(filePath)));

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,27 +1,25 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 
 export type WriteCasFileOptions = {
-  /** CAS file name, e.g. `ja-JP.page.cas.json`. */
+  /** CAS file name relative to `outputDir`, e.g. `ja-JP.page.cas.json`. */
   fileName: string;
   /** Signed JWT string to write. */
   jwt: string;
   /**
-   * Output directory. Relative paths resolve against `baseDir`
-   * (or the current working directory if omitted).
+   * Output directory. Relative paths (e.g. `./dist/cas`) resolve against
+   * the current working directory. Absolute paths are used as-is.
    */
   outputDir: string;
-  /**
-   * Base directory for a relative `outputDir`.
-   * Defaults to the current working directory.
-   */
-  baseDir?: string;
 };
 
-type CasDirOptions = Pick<WriteCasFileOptions, "outputDir" | "baseDir">;
+const isEmpty = (value: string): boolean => value.trim() === "";
 
-const isEmpty = (value: string): boolean => value === "";
+const isInsideCasDir = (dir: string, dest: string): boolean => {
+  const rel = relative(dir, dest);
+  return rel !== "" && !isAbsolute(rel) && !rel.split(sep).includes("..");
+};
 
 const isEnoent = (error: unknown): boolean =>
   typeof error === "object" &&
@@ -50,44 +48,46 @@ const unlinkMissing = async (filePath: string): Promise<void> => {
   }
 };
 
-/** Resolve a CAS output directory. Relative paths use `baseDir` or the current working directory. */
-export const resolveCasDir = ({
-  outputDir,
-  baseDir,
-}: CasDirOptions): string => {
+/** Resolve a CAS output directory. Relative paths use the current working directory. */
+export const resolveCasDir = (outputDir: string): string => {
   if (isEmpty(outputDir)) {
     throw new CaClientError("outputDir must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  return resolve(baseDir ?? process.cwd(), outputDir);
+  return resolve(outputDir);
 };
 
 export const casFilePath = ({
   fileName,
   outputDir,
-  baseDir,
-}: Pick<WriteCasFileOptions, "fileName" | "outputDir" | "baseDir">): string => {
+}: Pick<WriteCasFileOptions, "fileName" | "outputDir">): string => {
   if (isEmpty(fileName)) {
     throw new CaClientError("fileName must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  return join(resolveCasDir({ outputDir, baseDir }), fileName);
+  const dir = resolveCasDir(outputDir);
+  const dest = resolve(dir, fileName);
+  if (!isInsideCasDir(dir, dest)) {
+    throw new CaClientError("fileName must stay inside outputDir", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return dest;
 };
 
 export const writeCasFile = async ({
   fileName,
   jwt,
   outputDir,
-  baseDir,
 }: WriteCasFileOptions): Promise<void> => {
   if (isEmpty(jwt)) {
     throw new CaClientError("jwt must be a non-empty string", {
       code: CaClientErrorCode.Validation,
     });
   }
-  const dest = casFilePath({ fileName, outputDir, baseDir });
+  const dest = casFilePath({ fileName, outputDir });
   const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
 
   try {
@@ -100,22 +100,15 @@ export const writeCasFile = async ({
 
 export const deleteCasFiles = async (
   fileNames: string[],
-  { outputDir, baseDir }: CasDirOptions,
+  outputDir: string,
 ): Promise<void> => {
   if (fileNames.length === 0) {
     return;
   }
 
-  const dir = resolveCasDir({ outputDir, baseDir });
-
-  await Promise.all(
-    fileNames.map((fileName) => {
-      if (isEmpty(fileName)) {
-        throw new CaClientError("fileName must be a non-empty string", {
-          code: CaClientErrorCode.Validation,
-        });
-      }
-      return unlinkMissing(join(dir, fileName));
-    }),
+  const dests = fileNames.map((fileName) =>
+    casFilePath({ fileName, outputDir }),
   );
+
+  await Promise.all(dests.map((filePath) => unlinkMissing(filePath)));
 };

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,0 +1,121 @@
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { CaClientError, CaClientErrorCode } from "../errors";
+
+export type WriteCasFileOptions = {
+  /** CAS file name, e.g. `ja-JP.page.cas.json`. */
+  fileName: string;
+  /** Signed JWT string to write. */
+  jwt: string;
+  /**
+   * Output directory. Relative paths resolve against `baseDir`
+   * (or the current working directory if omitted).
+   */
+  outputDir: string;
+  /**
+   * Base directory for a relative `outputDir`.
+   * Defaults to the current working directory.
+   */
+  baseDir?: string;
+};
+
+type CasDirOptions = Pick<WriteCasFileOptions, "outputDir" | "baseDir">;
+
+const isEmpty = (value: string): boolean => value === "";
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "ENOENT";
+
+const toFileError = (message: string, error: unknown): CaClientError => {
+  if (error instanceof CaClientError) {
+    return error;
+  }
+  return new CaClientError(
+    `${message}: ${error instanceof Error ? error.message : String(error)}`,
+    { code: CaClientErrorCode.File, cause: error },
+  );
+};
+
+const unlinkMissing = async (filePath: string): Promise<void> => {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if (isEnoent(error)) {
+      return;
+    }
+    throw toFileError(`Failed to delete CAS file ${filePath}`, error);
+  }
+};
+
+/** Resolve a CAS output directory. Relative paths use `baseDir` or the current working directory. */
+export const resolveCasDir = ({
+  outputDir,
+  baseDir,
+}: CasDirOptions): string => {
+  if (isEmpty(outputDir)) {
+    throw new CaClientError("outputDir must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return resolve(baseDir ?? process.cwd(), outputDir);
+};
+
+export const casFilePath = ({
+  fileName,
+  outputDir,
+  baseDir,
+}: Pick<WriteCasFileOptions, "fileName" | "outputDir" | "baseDir">): string => {
+  if (isEmpty(fileName)) {
+    throw new CaClientError("fileName must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  return join(resolveCasDir({ outputDir, baseDir }), fileName);
+};
+
+export const writeCasFile = async ({
+  fileName,
+  jwt,
+  outputDir,
+  baseDir,
+}: WriteCasFileOptions): Promise<void> => {
+  if (isEmpty(jwt)) {
+    throw new CaClientError("jwt must be a non-empty string", {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+  const dest = casFilePath({ fileName, outputDir, baseDir });
+  const casContent = `${JSON.stringify([jwt], null, 2)}\n`;
+
+  try {
+    await mkdir(dirname(dest), { recursive: true });
+    await writeFile(dest, casContent, "utf8");
+  } catch (error) {
+    throw toFileError(`Failed to write CAS file ${dest}`, error);
+  }
+};
+
+export const deleteCasFiles = async (
+  fileNames: string[],
+  { outputDir, baseDir }: CasDirOptions,
+): Promise<void> => {
+  if (fileNames.length === 0) {
+    return;
+  }
+
+  const dir = resolveCasDir({ outputDir, baseDir });
+
+  await Promise.all(
+    fileNames.map((fileName) => {
+      if (isEmpty(fileName)) {
+        throw new CaClientError("fileName must be a non-empty string", {
+          code: CaClientErrorCode.Validation,
+        });
+      }
+      return unlinkMissing(join(dir, fileName));
+    }),
+  );
+};

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,6 +1,7 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
+import { isEnoent, toFileError } from "../file-utils";
 
 export type WriteCasFileOptions = {
   /** CAS file name relative to `outputDir`, e.g. `ja-JP.page.cas.json`. */
@@ -19,22 +20,6 @@ const isEmpty = (value: string): boolean => value.trim() === "";
 const isInsideCasDir = (dir: string, dest: string): boolean => {
   const rel = relative(dir, dest);
   return rel !== "" && !isAbsolute(rel) && !rel.split(sep).includes("..");
-};
-
-const isEnoent = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  "code" in error &&
-  error.code === "ENOENT";
-
-const toFileError = (message: string, error: unknown): CaClientError => {
-  if (error instanceof CaClientError) {
-    return error;
-  }
-  return new CaClientError(
-    `${message}: ${error instanceof Error ? error.message : String(error)}`,
-    { code: CaClientErrorCode.File, cause: error },
-  );
 };
 
 const unlinkMissing = async (filePath: string): Promise<void> => {

--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -113,6 +113,42 @@ test("detectDrift: CAS 記録の selector で再計算し、CIP 既定セレク�
   });
 });
 
+test("detectDrift: :nth-child を含むセレクタでも CAS と現 HTML を突き合わせられる", async () => {
+  const html = `
+    <article>
+      <p>First</p>
+      <p>Second</p>
+    </article>
+  `;
+  const firstSelector = "article p:nth-child(1)";
+  const secondSelector = "article p:nth-child(2)";
+  const firstIntegrity = await extractTextIntegrity(html, firstSelector);
+  const secondIntegrity = await extractTextIntegrity(html, secondSelector);
+
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "nth-child.cas.json", [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector: secondSelector,
+        integrity: secondIntegrity,
+      },
+      {
+        type: "TextTargetIntegrity",
+        cssSelector: firstSelector,
+        integrity: firstIntegrity,
+      },
+    ]);
+
+    await expect(
+      detectDrift({ html, fileName: "nth-child.cas.json", outputDir }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
+  });
+});
+
 test("detectDrift: text target が drift していれば drifted と current/expected を返す", async () => {
   const html = `
     <article>

--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -1,15 +1,17 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, expect, test } from "vitest";
+import { expect, test } from "vitest";
+import { casFilePath, writeCasFile } from "../cas-store/file";
+import { CaClientErrorCode } from "../errors";
 import { extractTargetsFromHtml } from "../targets/html";
 import { detectDrift } from "./compare";
 
 const extractTextIntegrity = async (
-  htmlContent: string,
+  html: string,
   cssSelector: string,
 ): Promise<string> => {
-  const targets = await extractTargetsFromHtml(htmlContent, {
+  const targets = await extractTargetsFromHtml(html, {
     textSelectors: [cssSelector],
     externalSelector: ":not(*)",
   });
@@ -30,36 +32,30 @@ const createCasJwt = (payload: Record<string, unknown>) => {
   return `${header}.${encodedPayload}.signature`;
 };
 
-const tempDirs: string[] = [];
-
-const writeCasFixture = (fileName: string, contents: unknown): string => {
-  const dir = mkdtempSync(join(tmpdir(), "ca-client-drift-"));
-  tempDirs.push(dir);
-  const casPath = join(dir, fileName);
-  writeFileSync(casPath, JSON.stringify(contents), "utf-8");
-  return casPath;
+const withTempDir = async (run: (dir: string) => Promise<void>) => {
+  const dir = await mkdtemp(join(tmpdir(), "ca-client-drift-"));
+  try {
+    await run(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 };
 
-const writeCasWithTargets = (
+const writeCasTargets = async (
+  outputDir: string,
   fileName: string,
   targets: Array<Record<string, string>>,
-  options?: { wrapped?: boolean },
-): string => {
-  const jwt = createCasJwt({ target: targets });
-  const item = options?.wrapped
-    ? { main: true as const, attestation: jwt }
-    : jwt;
-  return writeCasFixture(fileName, [item]);
+) => {
+  await writeCasFile({
+    fileName,
+    jwt: createCasJwt({ target: targets }),
+    outputDir,
+  });
+  return casFilePath({ fileName, outputDir });
 };
 
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
 test("detectDrift: CAS と現 HTML の target が一致すれば ok", async () => {
-  const htmlContent = `
+  const html = `
     <article>
       <h1 itemprop="headline">About</h1>
       <div itemprop="articleBody">Same body</div>
@@ -67,48 +63,58 @@ test("detectDrift: CAS と現 HTML の target が一致すれば ok", async () =
   `;
   const cssSelector =
     "article [itemprop='headline'], article [itemprop='articleBody']";
-  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+  const integrity = await extractTextIntegrity(html, cssSelector);
 
-  const casPath = writeCasWithTargets("about.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector,
-      integrity,
-    },
-  ]);
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "about.cas.json", [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector,
+        integrity,
+      },
+    ]);
 
-  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
-    status: "ok",
-    casFilePath: casPath,
+    await expect(
+      detectDrift({ html, fileName: "about.cas.json", outputDir }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
   });
 });
 
 test("detectDrift: CAS 記録の selector で再計算し、CIP 既定セレクタに依存しない", async () => {
-  const htmlContent = `
+  const html = `
     <main>
       <h1 itemprop="headline">News</h1>
       <div itemprop="articleBody">List body</div>
     </main>
   `;
   const cssSelector = "main";
-  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+  const integrity = await extractTextIntegrity(html, cssSelector);
 
-  const casPath = writeCasWithTargets("news.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector,
-      integrity,
-    },
-  ]);
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "news.cas.json", [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector,
+        integrity,
+      },
+    ]);
 
-  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
-    status: "ok",
-    casFilePath: casPath,
+    await expect(
+      detectDrift({ html, fileName: "news.cas.json", outputDir }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
   });
 });
 
 test("detectDrift: text target が drift していれば drifted と current/expected を返す", async () => {
-  const htmlContent = `
+  const html = `
     <article>
       <h1 itemprop="headline">Privacy</h1>
       <div itemprop="articleBody">Updated body</div>
@@ -116,39 +122,43 @@ test("detectDrift: text target が drift していれば drifted と current/exp
   `;
   const cssSelector =
     "article [itemprop='headline'], article [itemprop='articleBody']";
-  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+  const integrity = await extractTextIntegrity(html, cssSelector);
 
-  const casPath = writeCasWithTargets("privacy.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector,
-      integrity: "sha256-stale",
-    },
-  ]);
-
-  const result = await detectDrift(htmlContent, casPath);
-  expect(result).toEqual({
-    status: "drifted",
-    casFilePath: casPath,
-    current: [
-      {
-        type: "TextTargetIntegrity",
-        cssSelector,
-        integrity,
-      },
-    ],
-    expected: [
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "privacy.cas.json", [
       {
         type: "TextTargetIntegrity",
         cssSelector,
         integrity: "sha256-stale",
       },
-    ],
+    ]);
+
+    await expect(
+      detectDrift({ html, fileName: "privacy.cas.json", outputDir }),
+    ).resolves.toEqual({
+      status: "drifted",
+      casFilePath: dest,
+      current: [
+        {
+          type: "TextTargetIntegrity",
+          cssSelector,
+          integrity,
+        },
+      ],
+      expected: [
+        {
+          type: "TextTargetIntegrity",
+          cssSelector,
+          integrity: "sha256-stale",
+        },
+      ],
+    });
   });
 });
 
 test("detectDrift: .target-integrity 差分があれば drifted", async () => {
-  const htmlContent = `
+  const html = `
     <article>
       <h1 itemprop="headline">Message</h1>
       <div itemprop="articleBody">
@@ -158,148 +168,260 @@ test("detectDrift: .target-integrity 差分があれば drifted", async () => {
   `;
   const cssSelector =
     "article [itemprop='headline'], article [itemprop='articleBody']";
-  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+  const integrity = await extractTextIntegrity(html, cssSelector);
 
-  const casPath = writeCasWithTargets("chief-director.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector,
-      integrity,
-    },
-    {
-      type: "ExternalResourceTargetIntegrity",
-      integrity: "sha256-old",
-    },
-  ]);
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await writeCasTargets(outputDir, "chief-director.cas.json", [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector,
+        integrity,
+      },
+      {
+        type: "ExternalResourceTargetIntegrity",
+        integrity: "sha256-old",
+      },
+    ]);
 
-  await expect(detectDrift(htmlContent, casPath)).resolves.toMatchObject({
-    status: "drifted",
+    await expect(
+      detectDrift({
+        html,
+        fileName: "chief-director.cas.json",
+        outputDir,
+      }),
+    ).resolves.toMatchObject({
+      status: "drifted",
+    });
   });
 });
 
 test("detectDrift: externalSelector で CIP 以外のマークアップから抽出できる", async () => {
-  const htmlContent = `
+  const html = `
     <main>Body</main>
     <img class="op-resource" integrity="sha256-img" src="/a.png" />
   `;
-  const integrity = await extractTextIntegrity(htmlContent, "main");
+  const integrity = await extractTextIntegrity(html, "main");
 
-  const casPath = writeCasWithTargets("custom-external.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector: "main",
-      integrity,
-    },
-    {
-      type: "ExternalResourceTargetIntegrity",
-      integrity: "sha256-img",
-    },
-  ]);
-
-  await expect(
-    detectDrift(htmlContent, casPath, { externalSelector: ".op-resource" }),
-  ).resolves.toEqual({
-    status: "ok",
-    casFilePath: casPath,
-  });
-});
-
-test("detectDrift: CAS ファイルが存在しなければ cas_missing", async () => {
-  const htmlContent = `
-    <article>
-      <h1 itemprop="headline">About</h1>
-      <div itemprop="articleBody">Body</div>
-    </article>
-  `;
-  const missingCasPath = join(tmpdir(), "ca-client-drift-missing.cas.json");
-
-  await expect(detectDrift(htmlContent, missingCasPath)).resolves.toEqual({
-    status: "cas_missing",
-    casFilePath: missingCasPath,
-  });
-});
-
-test("detectDrift: 現 HTML に target が無ければ html_no_targets", async () => {
-  const casPath = writeCasWithTargets("empty.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      cssSelector: "main",
-      integrity: "sha256-xxx",
-    },
-  ]);
-
-  await expect(
-    detectDrift(`<article>itemprop の無い本文だけ</article>`, casPath),
-  ).resolves.toEqual({
-    status: "html_no_targets",
-    casFilePath: casPath,
-  });
-});
-
-test("detectDrift: CAS が不正なら cas_invalid", async () => {
-  const notJson = writeCasFixture("not-json.cas.json", "placeholder");
-  writeFileSync(notJson, "{", "utf-8");
-
-  await expect(detectDrift("<main>x</main>", notJson)).resolves.toMatchObject({
-    status: "cas_invalid",
-    casFilePath: notJson,
-  });
-
-  const notArray = writeCasFixture("object.cas.json", { attestation: "x" });
-  await expect(detectDrift("<main>x</main>", notArray)).resolves.toEqual({
-    status: "cas_invalid",
-    casFilePath: notArray,
-    reason: "Invalid CAS file format (expected JSON array with JWT string)",
-  });
-
-  const badJwt = writeCasFixture("bad-jwt.cas.json", ["not-a-jwt"]);
-  await expect(detectDrift("<main>x</main>", badJwt)).resolves.toMatchObject({
-    status: "cas_invalid",
-    casFilePath: badJwt,
-  });
-});
-
-test("detectDrift: { main, attestation } 形式の CAS も読める", async () => {
-  const htmlContent = `<main>Body</main>`;
-  const integrity = await extractTextIntegrity(htmlContent, "main");
-
-  const casPath = writeCasWithTargets(
-    "wrapped.cas.json",
-    [
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "custom-external.cas.json", [
       {
         type: "TextTargetIntegrity",
         cssSelector: "main",
         integrity,
       },
-    ],
-    { wrapped: true },
-  );
+      {
+        type: "ExternalResourceTargetIntegrity",
+        integrity: "sha256-img",
+      },
+    ]);
 
-  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
-    status: "ok",
-    casFilePath: casPath,
+    await expect(
+      detectDrift({
+        html,
+        fileName: "custom-external.cas.json",
+        outputDir,
+        externalSelector: ".op-resource",
+      }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
+  });
+});
+
+test("detectDrift: CAS ファイルが存在しなければ cas_missing", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
+    const dest = casFilePath({ fileName: "missing.cas.json", outputDir });
+
+    await expect(
+      detectDrift({
+        html: "<main>Body</main>",
+        fileName: "missing.cas.json",
+        outputDir,
+      }),
+    ).resolves.toEqual({
+      status: "cas_missing",
+      casFilePath: dest,
+    });
+  });
+});
+
+test("detectDrift: 現 HTML に target が無ければ html_no_targets", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(outputDir, "empty.cas.json", [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector: "main",
+        integrity: "sha256-xxx",
+      },
+    ]);
+
+    await expect(
+      detectDrift({
+        html: `<article>itemprop の無い本文だけ</article>`,
+        fileName: "empty.cas.json",
+        outputDir,
+      }),
+    ).resolves.toEqual({
+      status: "html_no_targets",
+      casFilePath: dest,
+    });
+  });
+});
+
+test("detectDrift: CAS が不正なら cas_invalid", async () => {
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
+
+    const notJson = casFilePath({ fileName: "not-json.cas.json", outputDir });
+    await writeFile(notJson, "{", "utf8");
+    await expect(
+      detectDrift({
+        html: "<main>x</main>",
+        fileName: "not-json.cas.json",
+        outputDir,
+      }),
+    ).resolves.toMatchObject({
+      status: "cas_invalid",
+      casFilePath: notJson,
+    });
+
+    const notArray = casFilePath({ fileName: "object.cas.json", outputDir });
+    await writeFile(notArray, JSON.stringify({ attestation: "x" }), "utf8");
+    await expect(
+      detectDrift({
+        html: "<main>x</main>",
+        fileName: "object.cas.json",
+        outputDir,
+      }),
+    ).resolves.toEqual({
+      status: "cas_invalid",
+      casFilePath: notArray,
+      reason: "Invalid CAS file format (expected JSON array with JWT string)",
+    });
+
+    const badJwt = casFilePath({ fileName: "bad-jwt.cas.json", outputDir });
+    await writeFile(badJwt, JSON.stringify(["not-a-jwt"]), "utf8");
+    await expect(
+      detectDrift({
+        html: "<main>x</main>",
+        fileName: "bad-jwt.cas.json",
+        outputDir,
+      }),
+    ).resolves.toMatchObject({
+      status: "cas_invalid",
+      casFilePath: badJwt,
+    });
+  });
+});
+
+test("detectDrift: { main, attestation } 形式の CAS も読める", async () => {
+  const html = `<main>Body</main>`;
+  const integrity = await extractTextIntegrity(html, "main");
+
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    await mkdir(outputDir, { recursive: true });
+    const dest = casFilePath({ fileName: "wrapped.cas.json", outputDir });
+    const jwt = createCasJwt({
+      target: [
+        {
+          type: "TextTargetIntegrity",
+          cssSelector: "main",
+          integrity,
+        },
+      ],
+    });
+    await writeFile(
+      dest,
+      `${JSON.stringify([{ main: true, attestation: jwt }], null, 2)}\n`,
+      "utf8",
+    );
+
+    await expect(
+      detectDrift({ html, fileName: "wrapped.cas.json", outputDir }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
   });
 });
 
 test("detectDrift: CAS に cssSelector が無いとき textSelector 引数で HTML を評価する", async () => {
-  const htmlContent = `<main>Main text</main>`;
-  const integrity = await extractTextIntegrity(htmlContent, "main");
+  const html = `<main>Main text</main>`;
+  const integrity = await extractTextIntegrity(html, "main");
 
-  const casPath = writeCasWithTargets("fallback-selector.cas.json", [
-    {
-      type: "TextTargetIntegrity",
-      integrity,
-    },
-  ]);
+  await withTempDir(async (dir) => {
+    const outputDir = join(dir, "cas");
+    const dest = await writeCasTargets(
+      outputDir,
+      "fallback-selector.cas.json",
+      [
+        {
+          type: "TextTargetIntegrity",
+          integrity,
+        },
+      ],
+    );
 
-  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
-    status: "html_no_targets",
-    casFilePath: casPath,
+    await expect(
+      detectDrift({
+        html,
+        fileName: "fallback-selector.cas.json",
+        outputDir,
+      }),
+    ).resolves.toEqual({
+      status: "html_no_targets",
+      casFilePath: dest,
+    });
+    await expect(
+      detectDrift({
+        html,
+        fileName: "fallback-selector.cas.json",
+        outputDir,
+        textSelector: "main",
+      }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
   });
-  await expect(
-    detectDrift(htmlContent, casPath, { textSelector: "main" }),
-  ).resolves.toEqual({
-    status: "ok",
-    casFilePath: casPath,
-  });
+});
+
+test("detectDrift: rejects an empty outputDir", async () => {
+  await Promise.all(
+    ["", "   "].map((outputDir) =>
+      expect(
+        detectDrift({
+          html: "<main>x</main>",
+          fileName: "a.cas.json",
+          outputDir,
+        }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "outputDir must be a non-empty string",
+      }),
+    ),
+  );
+});
+
+test("detectDrift: rejects an empty fileName", async () => {
+  await Promise.all(
+    ["", "   "].map((fileName) =>
+      expect(
+        detectDrift({ html: "<main>x</main>", fileName, outputDir: "cas" }),
+      ).rejects.toMatchObject({
+        name: "CaClientError",
+        code: CaClientErrorCode.Validation,
+        message: "fileName must be a non-empty string",
+      }),
+    ),
+  );
 });

--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -1,0 +1,305 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { extractTargetsFromHtml } from "../targets/html";
+import { detectDrift } from "./compare";
+
+const extractTextIntegrity = async (
+  htmlContent: string,
+  cssSelector: string,
+): Promise<string> => {
+  const targets = await extractTargetsFromHtml(htmlContent, {
+    textSelectors: [cssSelector],
+    externalSelector: ":not(*)",
+  });
+  const integrity = targets[0]?.integrity;
+  if (integrity === undefined) {
+    throw new Error("expected at least one extracted target");
+  }
+  return integrity;
+};
+
+const createCasJwt = (payload: Record<string, unknown>) => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "none", typ: "JWT" }),
+  ).toString("base64url");
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  return `${header}.${encodedPayload}.signature`;
+};
+
+const tempDirs: string[] = [];
+
+const writeCasFixture = (fileName: string, contents: unknown): string => {
+  const dir = mkdtempSync(join(tmpdir(), "ca-client-drift-"));
+  tempDirs.push(dir);
+  const casPath = join(dir, fileName);
+  writeFileSync(casPath, JSON.stringify(contents), "utf-8");
+  return casPath;
+};
+
+const writeCasWithTargets = (
+  fileName: string,
+  targets: Array<Record<string, string>>,
+  options?: { wrapped?: boolean },
+): string => {
+  const jwt = createCasJwt({ target: targets });
+  const item = options?.wrapped
+    ? { main: true as const, attestation: jwt }
+    : jwt;
+  return writeCasFixture(fileName, [item]);
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("detectDrift: CAS と現 HTML の target が一致すれば ok", async () => {
+  const htmlContent = `
+    <article>
+      <h1 itemprop="headline">About</h1>
+      <div itemprop="articleBody">Same body</div>
+    </article>
+  `;
+  const cssSelector =
+    "article [itemprop='headline'], article [itemprop='articleBody']";
+  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+
+  const casPath = writeCasWithTargets("about.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector,
+      integrity,
+    },
+  ]);
+
+  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
+    status: "ok",
+    casFilePath: casPath,
+  });
+});
+
+test("detectDrift: CAS 記録の selector で再計算し、CIP 既定セレクタに依存しない", async () => {
+  const htmlContent = `
+    <main>
+      <h1 itemprop="headline">News</h1>
+      <div itemprop="articleBody">List body</div>
+    </main>
+  `;
+  const cssSelector = "main";
+  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+
+  const casPath = writeCasWithTargets("news.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector,
+      integrity,
+    },
+  ]);
+
+  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
+    status: "ok",
+    casFilePath: casPath,
+  });
+});
+
+test("detectDrift: text target が drift していれば drifted と current/expected を返す", async () => {
+  const htmlContent = `
+    <article>
+      <h1 itemprop="headline">Privacy</h1>
+      <div itemprop="articleBody">Updated body</div>
+    </article>
+  `;
+  const cssSelector =
+    "article [itemprop='headline'], article [itemprop='articleBody']";
+  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+
+  const casPath = writeCasWithTargets("privacy.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector,
+      integrity: "sha256-stale",
+    },
+  ]);
+
+  const result = await detectDrift(htmlContent, casPath);
+  expect(result).toEqual({
+    status: "drifted",
+    casFilePath: casPath,
+    current: [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector,
+        integrity,
+      },
+    ],
+    expected: [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector,
+        integrity: "sha256-stale",
+      },
+    ],
+  });
+});
+
+test("detectDrift: .target-integrity 差分があれば drifted", async () => {
+  const htmlContent = `
+    <article>
+      <h1 itemprop="headline">Message</h1>
+      <div itemprop="articleBody">
+        <img class="target-integrity" integrity="sha256-new" src="/test.png" />
+      </div>
+    </article>
+  `;
+  const cssSelector =
+    "article [itemprop='headline'], article [itemprop='articleBody']";
+  const integrity = await extractTextIntegrity(htmlContent, cssSelector);
+
+  const casPath = writeCasWithTargets("chief-director.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector,
+      integrity,
+    },
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-old",
+    },
+  ]);
+
+  await expect(detectDrift(htmlContent, casPath)).resolves.toMatchObject({
+    status: "drifted",
+  });
+});
+
+test("detectDrift: externalSelector で CIP 以外のマークアップから抽出できる", async () => {
+  const htmlContent = `
+    <main>Body</main>
+    <img class="op-resource" integrity="sha256-img" src="/a.png" />
+  `;
+  const integrity = await extractTextIntegrity(htmlContent, "main");
+
+  const casPath = writeCasWithTargets("custom-external.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector: "main",
+      integrity,
+    },
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-img",
+    },
+  ]);
+
+  await expect(
+    detectDrift(htmlContent, casPath, { externalSelector: ".op-resource" }),
+  ).resolves.toEqual({
+    status: "ok",
+    casFilePath: casPath,
+  });
+});
+
+test("detectDrift: CAS ファイルが存在しなければ cas_missing", async () => {
+  const htmlContent = `
+    <article>
+      <h1 itemprop="headline">About</h1>
+      <div itemprop="articleBody">Body</div>
+    </article>
+  `;
+  const missingCasPath = join(tmpdir(), "ca-client-drift-missing.cas.json");
+
+  await expect(detectDrift(htmlContent, missingCasPath)).resolves.toEqual({
+    status: "cas_missing",
+    casFilePath: missingCasPath,
+  });
+});
+
+test("detectDrift: 現 HTML に target が無ければ html_no_targets", async () => {
+  const casPath = writeCasWithTargets("empty.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      cssSelector: "main",
+      integrity: "sha256-xxx",
+    },
+  ]);
+
+  await expect(
+    detectDrift(`<article>itemprop の無い本文だけ</article>`, casPath),
+  ).resolves.toEqual({
+    status: "html_no_targets",
+    casFilePath: casPath,
+  });
+});
+
+test("detectDrift: CAS が不正なら cas_invalid", async () => {
+  const notJson = writeCasFixture("not-json.cas.json", "placeholder");
+  writeFileSync(notJson, "{", "utf-8");
+
+  await expect(detectDrift("<main>x</main>", notJson)).resolves.toMatchObject({
+    status: "cas_invalid",
+    casFilePath: notJson,
+  });
+
+  const notArray = writeCasFixture("object.cas.json", { attestation: "x" });
+  await expect(detectDrift("<main>x</main>", notArray)).resolves.toEqual({
+    status: "cas_invalid",
+    casFilePath: notArray,
+    reason: "Invalid CAS file format (expected JSON array with JWT string)",
+  });
+
+  const badJwt = writeCasFixture("bad-jwt.cas.json", ["not-a-jwt"]);
+  await expect(detectDrift("<main>x</main>", badJwt)).resolves.toMatchObject({
+    status: "cas_invalid",
+    casFilePath: badJwt,
+  });
+});
+
+test("detectDrift: { main, attestation } 形式の CAS も読める", async () => {
+  const htmlContent = `<main>Body</main>`;
+  const integrity = await extractTextIntegrity(htmlContent, "main");
+
+  const casPath = writeCasWithTargets(
+    "wrapped.cas.json",
+    [
+      {
+        type: "TextTargetIntegrity",
+        cssSelector: "main",
+        integrity,
+      },
+    ],
+    { wrapped: true },
+  );
+
+  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
+    status: "ok",
+    casFilePath: casPath,
+  });
+});
+
+test("detectDrift: CAS に cssSelector が無いとき textSelector 引数で HTML を評価する", async () => {
+  const htmlContent = `<main>Main text</main>`;
+  const integrity = await extractTextIntegrity(htmlContent, "main");
+
+  const casPath = writeCasWithTargets("fallback-selector.cas.json", [
+    {
+      type: "TextTargetIntegrity",
+      integrity,
+    },
+  ]);
+
+  await expect(detectDrift(htmlContent, casPath)).resolves.toEqual({
+    status: "html_no_targets",
+    casFilePath: casPath,
+  });
+  await expect(
+    detectDrift(htmlContent, casPath, { textSelector: "main" }),
+  ).resolves.toEqual({
+    status: "ok",
+    casFilePath: casPath,
+  });
+});

--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -54,7 +54,7 @@ const writeCasTargets = async (
   return casFilePath({ fileName, outputDir });
 };
 
-test("detectDrift: CAS と現 HTML の target が一致すれば ok", async () => {
+test("detectDrift: returns ok when CAS targets match the current HTML", async () => {
   const html = `
     <article>
       <h1 itemprop="headline">About</h1>
@@ -84,7 +84,7 @@ test("detectDrift: CAS と現 HTML の target が一致すれば ok", async () =
   });
 });
 
-test("detectDrift: CAS 記録の selector で再計算し、CIP 既定セレクタに依存しない", async () => {
+test("detectDrift: recomputes with the CAS-recorded selector, not CIP defaults", async () => {
   const html = `
     <main>
       <h1 itemprop="headline">News</h1>
@@ -113,7 +113,7 @@ test("detectDrift: CAS 記録の selector で再計算し、CIP 既定セレク�
   });
 });
 
-test("detectDrift: :nth-child を含むセレクタでも CAS と現 HTML を突き合わせられる", async () => {
+test("detectDrift: matches CAS against current HTML when selectors include :nth-child", async () => {
   const html = `
     <article>
       <p>First</p>
@@ -149,7 +149,7 @@ test("detectDrift: :nth-child を含むセレクタでも CAS と現 HTML を突
   });
 });
 
-test("detectDrift: text target が drift していれば drifted と current/expected を返す", async () => {
+test("detectDrift: returns drifted with current and expected when a text target has drifted", async () => {
   const html = `
     <article>
       <h1 itemprop="headline">Privacy</h1>
@@ -193,7 +193,7 @@ test("detectDrift: text target が drift していれば drifted と current/exp
   });
 });
 
-test("detectDrift: .target-integrity 差分があれば drifted", async () => {
+test("detectDrift: returns drifted when .target-integrity values differ", async () => {
   const html = `
     <article>
       <h1 itemprop="headline">Message</h1>
@@ -232,7 +232,7 @@ test("detectDrift: .target-integrity 差分があれば drifted", async () => {
   });
 });
 
-test("detectDrift: externalSelector で CIP 以外のマークアップから抽出できる", async () => {
+test("detectDrift: extracts external resources from non-CIP markup via externalSelector", async () => {
   const html = `
     <main>Body</main>
     <img class="op-resource" integrity="sha256-img" src="/a.png" />
@@ -267,7 +267,7 @@ test("detectDrift: externalSelector で CIP 以外のマークアップから抽
   });
 });
 
-test("detectDrift: CAS ファイルが存在しなければ cas_missing", async () => {
+test("detectDrift: returns cas_missing when the CAS file does not exist", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "cas");
     await mkdir(outputDir, { recursive: true });
@@ -286,7 +286,7 @@ test("detectDrift: CAS ファイルが存在しなければ cas_missing", async 
   });
 });
 
-test("detectDrift: 現 HTML に target が無ければ html_no_targets", async () => {
+test("detectDrift: returns html_no_targets when the current HTML has no targets", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "cas");
     const dest = await writeCasTargets(outputDir, "empty.cas.json", [
@@ -299,7 +299,7 @@ test("detectDrift: 現 HTML に target が無ければ html_no_targets", async (
 
     await expect(
       detectDrift({
-        html: `<article>itemprop の無い本文だけ</article>`,
+        html: `<article>body only, without itemprop</article>`,
         fileName: "empty.cas.json",
         outputDir,
       }),
@@ -310,7 +310,7 @@ test("detectDrift: 現 HTML に target が無ければ html_no_targets", async (
   });
 });
 
-test("detectDrift: CAS が不正なら cas_invalid", async () => {
+test("detectDrift: returns cas_invalid when the CAS is invalid", async () => {
   await withTempDir(async (dir) => {
     const outputDir = join(dir, "cas");
     await mkdir(outputDir, { recursive: true });
@@ -357,7 +357,7 @@ test("detectDrift: CAS が不正なら cas_invalid", async () => {
   });
 });
 
-test("detectDrift: { main, attestation } 形式の CAS も読める", async () => {
+test("detectDrift: reads a CAS in { main, attestation } form", async () => {
   const html = `<main>Body</main>`;
   const integrity = await extractTextIntegrity(html, "main");
 
@@ -389,7 +389,7 @@ test("detectDrift: { main, attestation } 形式の CAS も読める", async () =
   });
 });
 
-test("detectDrift: CAS に cssSelector が無いとき textSelector 引数で HTML を評価する", async () => {
+test("detectDrift: evaluates HTML with the textSelector option when CAS has no cssSelector", async () => {
   const html = `<main>Main text</main>`;
   const integrity = await extractTextIntegrity(html, "main");
 

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -1,6 +1,8 @@
 import { ContentAttestationSet } from "@originator-profile/model";
-import { existsSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { decodeJwtPayload } from "../auth/jwt";
+import { casFilePath } from "../cas-store/file";
+import { CaClientError, CaClientErrorCode } from "../errors";
 import { isRecord } from "../is-record";
 import {
   DEFAULT_EXTERNAL_SELECTOR,
@@ -24,15 +26,24 @@ export type DriftResult =
     };
 
 export type DetectDriftOptions = {
-  /** TextTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  /** Built HTML to recompute target integrity from. */
+  html: string;
+  /** CAS file name relative to `outputDir`, e.g. `ja-JP.page.cas.json`. */
+  fileName: string;
+  /**
+   * Directory containing the CAS file. Relative paths (e.g. `./dist/cas`)
+   * resolve against the current working directory. Absolute paths are used as-is.
+   */
+  outputDir: string;
+  /** CSS selector for TextTargetIntegrity when CAS has none. */
   textSelector?: string;
-  /** HtmlTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  /** CSS selector for HtmlTargetIntegrity when CAS has none. */
   htmlSelector?: string;
-  /** VisibleTextTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  /** CSS selector for VisibleTextTargetIntegrity when CAS has none. */
   visibleTextSelector?: string;
   /**
-   * ExternalResourceTargetIntegrity 要素の CSS セレクタ。
-   * 省略時は CAS の cssSelector、それも無ければ `.target-integrity`
+   * CSS selector for ExternalResourceTargetIntegrity elements.
+   * Defaults to the CAS `cssSelector`, then `.target-integrity`.
    */
   externalSelector?: string;
 };
@@ -45,6 +56,22 @@ type CasTarget = {
 
 const INVALID_CAS_FORMAT =
   "Invalid CAS file format (expected JSON array with JWT string)";
+
+const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "ENOENT";
+
+const toFileError = (message: string, error: unknown): CaClientError => {
+  if (error instanceof CaClientError) {
+    return error;
+  }
+  return new CaClientError(
+    `${message}: ${error instanceof Error ? error.message : String(error)}`,
+    { code: CaClientErrorCode.File, cause: error },
+  );
+};
 
 const jwtFromCasItem = (item: unknown): string | undefined => {
   if (typeof item === "string") {
@@ -109,31 +136,26 @@ type ReadCasTargetsResult =
   | { ok: true; targets: NormalizedTarget[] }
   | { ok: false; reason: string };
 
-const readCasTargets = (casFilePath: string): ReadCasTargetsResult => {
-  if (!existsSync(casFilePath)) {
-    return { ok: false, reason: "CAS file not found" };
+const parseCasTargets = (casFileContent: string): ReadCasTargetsResult => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(casFileContent);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: detail };
+  }
+
+  const cas = ContentAttestationSet.safeParse(parsed);
+  if (!cas.success) {
+    return { ok: false, reason: INVALID_CAS_FORMAT };
+  }
+
+  const jwt = jwtFromCasItem(cas.data[0]);
+  if (!jwt) {
+    return { ok: false, reason: INVALID_CAS_FORMAT };
   }
 
   try {
-    const casFileContent = readFileSync(casFilePath, "utf-8");
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(casFileContent);
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      return { ok: false, reason: detail };
-    }
-
-    const cas = ContentAttestationSet.safeParse(parsed);
-    if (!cas.success) {
-      return { ok: false, reason: INVALID_CAS_FORMAT };
-    }
-
-    const jwt = jwtFromCasItem(cas.data[0]);
-    if (!jwt) {
-      return { ok: false, reason: INVALID_CAS_FORMAT };
-    }
-
     const payload = decodeJwtPayload(jwt);
     return { ok: true, targets: normalizeTargets(payload.target) };
   } catch (error) {
@@ -164,71 +186,74 @@ const selectorsForType = (
 
 const extractOptionsFromCas = (
   casTargets: NormalizedTarget[],
-  options?: DetectDriftOptions,
+  options: DetectDriftOptions,
 ): ExtractTargetsOptions => ({
   textSelectors: selectorsForType(
     casTargets,
     "TextTargetIntegrity",
-    options?.textSelector,
+    options.textSelector,
   ),
   htmlSelectors: selectorsForType(
     casTargets,
     "HtmlTargetIntegrity",
-    options?.htmlSelector,
+    options.htmlSelector,
   ),
   visibleTextSelectors: selectorsForType(
     casTargets,
     "VisibleTextTargetIntegrity",
-    options?.visibleTextSelector,
+    options.visibleTextSelector,
   ),
   externalSelector:
-    options?.externalSelector ??
+    options.externalSelector ??
     casTargets.find(
       (target) => target.type === "ExternalResourceTargetIntegrity",
     )?.cssSelector ??
     DEFAULT_EXTERNAL_SELECTOR,
 });
 
-/**
- * CAS payload に記録された cssSelector で現 HTML の target を再計算し、
- * CAS の target との一致（drift の有無）を判定する。
- *
- * `@originator-profile/verify` による暗号検証とは別物。ビルド後 HTML と
- * 既存 CAS 記録の target integrity が一致するかを見る発行パイプライン向け API。
- */
 export const detectDrift = async (
-  htmlContent: string,
-  casFilePath: string,
-  options?: DetectDriftOptions,
+  options: DetectDriftOptions,
 ): Promise<DriftResult> => {
-  const casRead = readCasTargets(casFilePath);
-  if (!casRead.ok) {
-    if (casRead.reason === "CAS file not found") {
-      return { status: "cas_missing", casFilePath };
+  const dest = casFilePath({
+    fileName: options.fileName,
+    outputDir: options.outputDir,
+  });
+
+  let casFileContent: string;
+  try {
+    casFileContent = await readFile(dest, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) {
+      return { status: "cas_missing", casFilePath: dest };
     }
-    return { status: "cas_invalid", casFilePath, reason: casRead.reason };
+    throw toFileError(`Failed to read CAS file ${dest}`, error);
+  }
+
+  const casRead = parseCasTargets(casFileContent);
+  if (!casRead.ok) {
+    return { status: "cas_invalid", casFilePath: dest, reason: casRead.reason };
   }
 
   const casTargets = casRead.targets;
   const currentTargets = normalizeTargets(
     await extractTargetsFromHtml(
-      htmlContent,
+      options.html,
       extractOptionsFromCas(casTargets, options),
     ),
   );
 
   if (currentTargets.length === 0) {
-    return { status: "html_no_targets", casFilePath };
+    return { status: "html_no_targets", casFilePath: dest };
   }
 
   if (!areTargetsEqual(currentTargets, casTargets)) {
     return {
       status: "drifted",
-      casFilePath,
+      casFilePath: dest,
       current: currentTargets,
       expected: casTargets,
     };
   }
 
-  return { status: "ok", casFilePath };
+  return { status: "ok", casFilePath: dest };
 };

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -2,16 +2,19 @@ import { ContentAttestationSet } from "@originator-profile/model";
 import { readFile } from "node:fs/promises";
 import { decodeJwtPayload } from "../auth/jwt";
 import { casFilePath } from "../cas-store/file";
-import { CaClientError, CaClientErrorCode } from "../errors";
+import { isEnoent, toFileError } from "../file-utils";
 import { isRecord } from "../is-record";
 import {
   DEFAULT_EXTERNAL_SELECTOR,
   extractTargetsFromHtml,
-  type ExtractedTarget,
   type ExtractTargetsOptions,
 } from "../targets/html";
 
-export type NormalizedTarget = ExtractedTarget;
+export type NormalizedTarget = {
+  type: string;
+  integrity: string;
+  cssSelector?: string;
+};
 
 export type DriftResult =
   | { status: "ok"; casFilePath: string }
@@ -56,22 +59,6 @@ type CasTarget = {
 
 const INVALID_CAS_FORMAT =
   "Invalid CAS file format (expected JSON array with JWT string)";
-
-const isEnoent = (error: unknown): boolean =>
-  typeof error === "object" &&
-  error !== null &&
-  "code" in error &&
-  error.code === "ENOENT";
-
-const toFileError = (message: string, error: unknown): CaClientError => {
-  if (error instanceof CaClientError) {
-    return error;
-  }
-  return new CaClientError(
-    `${message}: ${error instanceof Error ? error.message : String(error)}`,
-    { code: CaClientErrorCode.File, cause: error },
-  );
-};
 
 const jwtFromCasItem = (item: unknown): string | undefined => {
   if (typeof item === "string") {

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -92,8 +92,10 @@ const normalizeTargets = (targets: unknown): NormalizedTarget[] => {
         : { type: target.type, integrity: target.integrity },
     )
     .sort((a, b) => {
-      const left = `${a.type}:${a.cssSelector ?? ""}:${a.integrity}`;
-      const right = `${b.type}:${b.cssSelector ?? ""}:${b.integrity}`;
+      // NUL separates fields so CSS selectors containing ":"
+      // (e.g. :nth-child, :not) cannot collide with adjacent fields.
+      const left = `${a.type}\0${a.cssSelector ?? ""}\0${a.integrity}`;
+      const right = `${b.type}\0${b.cssSelector ?? ""}\0${b.integrity}`;
       return left.localeCompare(right);
     });
 };
@@ -108,6 +110,8 @@ const areTargetsEqual = (
 
   return currentTargets.every((target, index) => {
     const casTarget = casTargets[index];
+    // Skip cssSelector when CAS omits it (ExternalResourceTargetIntegrity or
+    // fallback selectors). Current targets may still have cssSelector.
     const cssSelectorEqual =
       casTarget?.cssSelector === undefined ||
       target.cssSelector === casTarget.cssSelector;

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -1,0 +1,234 @@
+import { ContentAttestationSet } from "@originator-profile/model";
+import { existsSync, readFileSync } from "node:fs";
+import { decodeJwtPayload } from "../auth/jwt";
+import { isRecord } from "../is-record";
+import {
+  DEFAULT_EXTERNAL_SELECTOR,
+  extractTargetsFromHtml,
+  type ExtractedTarget,
+  type ExtractTargetsOptions,
+} from "../targets/html";
+
+export type NormalizedTarget = ExtractedTarget;
+
+export type DriftResult =
+  | { status: "ok"; casFilePath: string }
+  | { status: "cas_missing"; casFilePath: string }
+  | { status: "cas_invalid"; casFilePath: string; reason: string }
+  | { status: "html_no_targets"; casFilePath: string }
+  | {
+      status: "drifted";
+      casFilePath: string;
+      current: NormalizedTarget[];
+      expected: NormalizedTarget[];
+    };
+
+export type DetectDriftOptions = {
+  /** TextTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  textSelector?: string;
+  /** HtmlTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  htmlSelector?: string;
+  /** VisibleTextTargetIntegrity の CSS セレクタ。CAS に cssSelector が無いとき使う */
+  visibleTextSelector?: string;
+  /**
+   * ExternalResourceTargetIntegrity 要素の CSS セレクタ。
+   * 省略時は CAS の cssSelector、それも無ければ `.target-integrity`
+   */
+  externalSelector?: string;
+};
+
+type CasTarget = {
+  type: string;
+  cssSelector?: string;
+  integrity: string;
+};
+
+const INVALID_CAS_FORMAT =
+  "Invalid CAS file format (expected JSON array with JWT string)";
+
+const jwtFromCasItem = (item: unknown): string | undefined => {
+  if (typeof item === "string") {
+    return item;
+  }
+  if (isRecord(item) && typeof item.attestation === "string") {
+    return item.attestation;
+  }
+  return undefined;
+};
+
+const isCasTarget = (value: unknown): value is CasTarget =>
+  isRecord(value) &&
+  typeof value.type === "string" &&
+  typeof value.integrity === "string";
+
+const normalizeTargets = (targets: unknown): NormalizedTarget[] => {
+  if (!Array.isArray(targets)) {
+    return [];
+  }
+
+  return targets
+    .filter(isCasTarget)
+    .map((target) =>
+      typeof target.cssSelector === "string"
+        ? {
+            type: target.type,
+            integrity: target.integrity,
+            cssSelector: target.cssSelector,
+          }
+        : { type: target.type, integrity: target.integrity },
+    )
+    .sort((a, b) => {
+      const left = `${a.type}:${a.cssSelector ?? ""}:${a.integrity}`;
+      const right = `${b.type}:${b.cssSelector ?? ""}:${b.integrity}`;
+      return left.localeCompare(right);
+    });
+};
+
+const areTargetsEqual = (
+  currentTargets: NormalizedTarget[],
+  casTargets: NormalizedTarget[],
+): boolean => {
+  if (currentTargets.length !== casTargets.length) {
+    return false;
+  }
+
+  return currentTargets.every((target, index) => {
+    const casTarget = casTargets[index];
+    const cssSelectorEqual =
+      casTarget?.cssSelector === undefined ||
+      target.cssSelector === casTarget.cssSelector;
+    return (
+      target.type === casTarget?.type &&
+      target.integrity === casTarget?.integrity &&
+      cssSelectorEqual
+    );
+  });
+};
+
+type ReadCasTargetsResult =
+  | { ok: true; targets: NormalizedTarget[] }
+  | { ok: false; reason: string };
+
+const readCasTargets = (casFilePath: string): ReadCasTargetsResult => {
+  if (!existsSync(casFilePath)) {
+    return { ok: false, reason: "CAS file not found" };
+  }
+
+  try {
+    const casFileContent = readFileSync(casFilePath, "utf-8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(casFileContent);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      return { ok: false, reason: detail };
+    }
+
+    const cas = ContentAttestationSet.safeParse(parsed);
+    if (!cas.success) {
+      return { ok: false, reason: INVALID_CAS_FORMAT };
+    }
+
+    const jwt = jwtFromCasItem(cas.data[0]);
+    if (!jwt) {
+      return { ok: false, reason: INVALID_CAS_FORMAT };
+    }
+
+    const payload = decodeJwtPayload(jwt);
+    return { ok: true, targets: normalizeTargets(payload.target) };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: detail };
+  }
+};
+
+const selectorsForType = (
+  casTargets: NormalizedTarget[],
+  type: string,
+  fallback?: string,
+): string[] => {
+  const fromCas = [
+    ...new Set(
+      casTargets.flatMap((target) =>
+        target.type === type && typeof target.cssSelector === "string"
+          ? [target.cssSelector]
+          : [],
+      ),
+    ),
+  ];
+  if (fromCas.length > 0) {
+    return fromCas;
+  }
+  return fallback && fallback.length > 0 ? [fallback] : [];
+};
+
+const extractOptionsFromCas = (
+  casTargets: NormalizedTarget[],
+  options?: DetectDriftOptions,
+): ExtractTargetsOptions => ({
+  textSelectors: selectorsForType(
+    casTargets,
+    "TextTargetIntegrity",
+    options?.textSelector,
+  ),
+  htmlSelectors: selectorsForType(
+    casTargets,
+    "HtmlTargetIntegrity",
+    options?.htmlSelector,
+  ),
+  visibleTextSelectors: selectorsForType(
+    casTargets,
+    "VisibleTextTargetIntegrity",
+    options?.visibleTextSelector,
+  ),
+  externalSelector:
+    options?.externalSelector ??
+    casTargets.find(
+      (target) => target.type === "ExternalResourceTargetIntegrity",
+    )?.cssSelector ??
+    DEFAULT_EXTERNAL_SELECTOR,
+});
+
+/**
+ * CAS payload に記録された cssSelector で現 HTML の target を再計算し、
+ * CAS の target との一致（drift の有無）を判定する。
+ *
+ * `@originator-profile/verify` による暗号検証とは別物。ビルド後 HTML と
+ * 既存 CAS 記録の target integrity が一致するかを見る発行パイプライン向け API。
+ */
+export const detectDrift = async (
+  htmlContent: string,
+  casFilePath: string,
+  options?: DetectDriftOptions,
+): Promise<DriftResult> => {
+  const casRead = readCasTargets(casFilePath);
+  if (!casRead.ok) {
+    if (casRead.reason === "CAS file not found") {
+      return { status: "cas_missing", casFilePath };
+    }
+    return { status: "cas_invalid", casFilePath, reason: casRead.reason };
+  }
+
+  const casTargets = casRead.targets;
+  const currentTargets = normalizeTargets(
+    await extractTargetsFromHtml(
+      htmlContent,
+      extractOptionsFromCas(casTargets, options),
+    ),
+  );
+
+  if (currentTargets.length === 0) {
+    return { status: "html_no_targets", casFilePath };
+  }
+
+  if (!areTargetsEqual(currentTargets, casTargets)) {
+    return {
+      status: "drifted",
+      casFilePath,
+      current: currentTargets,
+      expected: casTargets,
+    };
+  }
+
+  return { status: "ok", casFilePath };
+};

--- a/packages/ca-client/src/errors.ts
+++ b/packages/ca-client/src/errors.ts
@@ -4,6 +4,7 @@ export const CaClientErrorCode = {
   Validation: "CA_VALIDATION",
   Http: "CA_HTTP",
   Response: "CA_RESPONSE",
+  File: "CA_FILE",
 } as const;
 
 export type CaClientErrorCode =

--- a/packages/ca-client/src/file-utils.test.ts
+++ b/packages/ca-client/src/file-utils.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "vitest";
+import { CaClientError, CaClientErrorCode } from "./errors";
+import { isEnoent, toFileError } from "./file-utils";
+
+test("isEnoent: is true only for objects with code ENOENT", () => {
+  expect(isEnoent({ code: "ENOENT" })).toBe(true);
+  expect(isEnoent(Object.assign(new Error("missing"), { code: "ENOENT" }))).toBe(
+    true,
+  );
+
+  expect(isEnoent({ code: "EACCES" })).toBe(false);
+  expect(isEnoent(new Error("missing"))).toBe(false);
+  expect(isEnoent(null)).toBe(false);
+  expect(isEnoent("ENOENT")).toBe(false);
+});
+
+test("toFileError: returns the same CaClientError", () => {
+  const error = new CaClientError("already wrapped", {
+    code: CaClientErrorCode.Validation,
+  });
+
+  expect(toFileError("Failed to read", error)).toBe(error);
+});
+
+test("toFileError: wraps a non-CaClientError as a File error", () => {
+  const cause = new Error("disk full");
+  const wrapped = toFileError("Failed to write CAS file", cause);
+
+  expect(wrapped).toBeInstanceOf(CaClientError);
+  expect(wrapped.code).toBe(CaClientErrorCode.File);
+  expect(wrapped.message).toBe("Failed to write CAS file: disk full");
+  expect(wrapped.cause).toBe(cause);
+});

--- a/packages/ca-client/src/file-utils.test.ts
+++ b/packages/ca-client/src/file-utils.test.ts
@@ -4,9 +4,9 @@ import { isEnoent, toFileError } from "./file-utils";
 
 test("isEnoent: is true only for objects with code ENOENT", () => {
   expect(isEnoent({ code: "ENOENT" })).toBe(true);
-  expect(isEnoent(Object.assign(new Error("missing"), { code: "ENOENT" }))).toBe(
-    true,
-  );
+  expect(
+    isEnoent(Object.assign(new Error("missing"), { code: "ENOENT" })),
+  ).toBe(true);
 
   expect(isEnoent({ code: "EACCES" })).toBe(false);
   expect(isEnoent(new Error("missing"))).toBe(false);

--- a/packages/ca-client/src/file-utils.ts
+++ b/packages/ca-client/src/file-utils.ts
@@ -1,0 +1,17 @@
+import { CaClientError, CaClientErrorCode } from "./errors";
+
+export const isEnoent = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "ENOENT";
+
+export const toFileError = (message: string, error: unknown): CaClientError => {
+  if (error instanceof CaClientError) {
+    return error;
+  }
+  return new CaClientError(
+    `${message}: ${error instanceof Error ? error.message : String(error)}`,
+    { code: CaClientErrorCode.File, cause: error },
+  );
+};

--- a/packages/ca-client/src/index.test.ts
+++ b/packages/ca-client/src/index.test.ts
@@ -1,15 +1,17 @@
 import { expect, test } from "vitest";
 import * as publicApi from "./index";
 
-test("public API: exports createCaClient, writeCasFile, and error types", () => {
+test("public API: exports createCaClient, writeCasFile, detectDrift, and error types", () => {
   expect(typeof publicApi.createCaClient).toBe("function");
   expect(typeof publicApi.writeCasFile).toBe("function");
+  expect(typeof publicApi.detectDrift).toBe("function");
   expect(typeof publicApi.isUnauthorized).toBe("function");
   expect(publicApi.CaClientError).toBeDefined();
   expect(Object.keys(publicApi).sort()).toEqual([
     "CaClientError",
     "CaClientErrorCode",
     "createCaClient",
+    "detectDrift",
     "isUnauthorized",
     "writeCasFile",
   ]);
@@ -25,4 +27,9 @@ test("public API: does not export low-level APIs from index", () => {
   expect(api.deleteCasFiles).toBeUndefined();
   expect(api.resolveCasDir).toBeUndefined();
   expect(api.casFilePath).toBeUndefined();
+  expect(api.extractTargetsFromHtml).toBeUndefined();
+  expect(api.extractTextTargetIntegrity).toBeUndefined();
+  expect(api.htmlMatchesCasTargets).toBeUndefined();
+  expect(api.normalizeTargets).toBeUndefined();
+  expect(api.decodeJwtPayload).toBeUndefined();
 });

--- a/packages/ca-client/src/index.test.ts
+++ b/packages/ca-client/src/index.test.ts
@@ -1,8 +1,9 @@
 import { expect, test } from "vitest";
 import * as publicApi from "./index";
 
-test("public API: exports createCaClient and error types", () => {
+test("public API: exports createCaClient, writeCasFile, and error types", () => {
   expect(typeof publicApi.createCaClient).toBe("function");
+  expect(typeof publicApi.writeCasFile).toBe("function");
   expect(typeof publicApi.isUnauthorized).toBe("function");
   expect(publicApi.CaClientError).toBeDefined();
   expect(Object.keys(publicApi).sort()).toEqual([
@@ -10,6 +11,7 @@ test("public API: exports createCaClient and error types", () => {
     "CaClientErrorCode",
     "createCaClient",
     "isUnauthorized",
+    "writeCasFile",
   ]);
 });
 
@@ -20,4 +22,7 @@ test("public API: does not export low-level APIs from index", () => {
   expect(api.TokenManager).toBeUndefined();
   expect(api.serverSignOptions).toBeUndefined();
   expect(api.signByCaServer).toBeUndefined();
+  expect(api.deleteCasFiles).toBeUndefined();
+  expect(api.resolveCasDir).toBeUndefined();
+  expect(api.casFilePath).toBeUndefined();
 });

--- a/packages/ca-client/src/index.ts
+++ b/packages/ca-client/src/index.ts
@@ -4,4 +4,10 @@ export {
   type CaClientConfig,
 } from "./ca-client/create-ca-client";
 export { writeCasFile, type WriteCasFileOptions } from "./cas-store/file";
+export {
+  detectDrift,
+  type DetectDriftOptions,
+  type DriftResult,
+  type NormalizedTarget,
+} from "./drift/compare";
 export { CaClientError, CaClientErrorCode, isUnauthorized } from "./errors";

--- a/packages/ca-client/src/index.ts
+++ b/packages/ca-client/src/index.ts
@@ -3,4 +3,5 @@ export {
   type CaClient,
   type CaClientConfig,
 } from "./ca-client/create-ca-client";
+export { writeCasFile, type WriteCasFileOptions } from "./cas-store/file";
 export { CaClientError, CaClientErrorCode, isUnauthorized } from "./errors";

--- a/packages/ca-client/src/targets/html.test.ts
+++ b/packages/ca-client/src/targets/html.test.ts
@@ -1,0 +1,93 @@
+import { createIntegrity } from "@originator-profile/sign";
+import { JSDOM } from "jsdom";
+import { expect, test } from "vitest";
+import {
+  DEFAULT_EXTERNAL_SELECTOR,
+  extractExternalTargetIntegrities,
+  extractTargetsFromHtml,
+} from "./html";
+
+test("extractTargetsFromHtml: uses the given selector, not CIP itemprop defaults", async () => {
+  const html = `
+    <article>
+      <h1 itemprop="headline">Headline</h1>
+      <div itemprop="articleBody">Body</div>
+      <main>Main text</main>
+    </article>
+  `;
+
+  const fromMain = await extractTargetsFromHtml(html, {
+    textSelectors: ["main"],
+    externalSelector: ":not(*)",
+  });
+  const fromItemprop = await extractTargetsFromHtml(html, {
+    textSelectors: [
+      "article [itemprop='headline'], article [itemprop='articleBody']",
+    ],
+    externalSelector: ":not(*)",
+  });
+
+  expect(fromMain).toHaveLength(1);
+  expect(fromItemprop).toHaveLength(1);
+  expect(fromMain[0]?.cssSelector).toBe("main");
+  expect(fromItemprop[0]?.cssSelector).toBe(
+    "article [itemprop='headline'], article [itemprop='articleBody']",
+  );
+  expect(fromMain[0]?.integrity).not.toBe(fromItemprop[0]?.integrity);
+});
+
+test("extractTargetsFromHtml: returns empty when the selector matches nothing", async () => {
+  const html = `
+    <article>
+      <h1 itemprop="headline">Headline</h1>
+      <div itemprop="articleBody">Body</div>
+    </article>
+  `;
+
+  expect(
+    await extractTargetsFromHtml(html, {
+      textSelectors: ["main"],
+      externalSelector: ":not(*)",
+    }),
+  ).toEqual([]);
+});
+
+test("extractTargetsFromHtml: matches createIntegrity for TextTargetIntegrity", async () => {
+  const html = `<html><body><main>Hello, world!</main></body></html>`;
+  const cssSelector = "main";
+  const document = new JSDOM(html).window.document;
+  const canonical = await createIntegrity(
+    "sha256",
+    { type: "TextTargetIntegrity", cssSelector },
+    document,
+  );
+
+  const extracted = await extractTargetsFromHtml(html, {
+    textSelectors: [cssSelector],
+    externalSelector: ":not(*)",
+  });
+
+  expect(extracted).toEqual([
+    {
+      type: "TextTargetIntegrity",
+      cssSelector,
+      integrity: canonical?.integrity,
+    },
+  ]);
+});
+
+test("extractExternalTargetIntegrities: uses the given selector", () => {
+  const html = `
+    <img class="target-integrity" integrity="sha256-default" src="/a.png" />
+    <img class="my-resource" integrity="sha256-custom" src="/b.png" />
+  `;
+  const document = new JSDOM(html).window.document;
+
+  expect(extractExternalTargetIntegrities(document)).toEqual([
+    { type: "ExternalResourceTargetIntegrity", integrity: "sha256-default" },
+  ]);
+  expect(extractExternalTargetIntegrities(document, ".my-resource")).toEqual([
+    { type: "ExternalResourceTargetIntegrity", integrity: "sha256-custom" },
+  ]);
+  expect(DEFAULT_EXTERNAL_SELECTOR).toBe(".target-integrity");
+});

--- a/packages/ca-client/src/targets/html.ts
+++ b/packages/ca-client/src/targets/html.ts
@@ -1,0 +1,104 @@
+import { createIntegrity } from "@originator-profile/sign";
+import { JSDOM } from "jsdom";
+
+export type ExtractedTarget = {
+  type: string;
+  integrity: string;
+  cssSelector?: string;
+};
+
+export type ExtractTargetsOptions = {
+  textSelectors?: string[];
+  htmlSelectors?: string[];
+  visibleTextSelectors?: string[];
+  /** CSS selector for ExternalResourceTargetIntegrity elements */
+  externalSelector?: string;
+};
+
+/**
+ * Default selector for ExternalResourceTargetIntegrity when CAS に cssSelector が無く、
+ * 引数も省略された場合。呼び出し側の `externalSelector` で上書きできる。
+ */
+export const DEFAULT_EXTERNAL_SELECTOR = ".target-integrity";
+
+const uniqueSelectors = (selectors: string[] | undefined): string[] => [
+  ...new Set((selectors ?? []).filter((selector) => selector.length > 0)),
+];
+
+const toExtractedTarget = (
+  type: string,
+  integrity: string,
+  cssSelector?: string,
+): ExtractedTarget =>
+  cssSelector === undefined
+    ? { type, integrity }
+    : { type, integrity, cssSelector };
+
+export const extractExternalTargetIntegrities = (
+  document: Document,
+  cssSelector: string = DEFAULT_EXTERNAL_SELECTOR,
+): ExtractedTarget[] => {
+  const targets: ExtractedTarget[] = [];
+  for (const element of document.querySelectorAll(cssSelector)) {
+    const integrity = element.getAttribute("integrity");
+    if (integrity && /^sha(256|384|512)-/.test(integrity)) {
+      targets.push({
+        type: "ExternalResourceTargetIntegrity",
+        integrity,
+      });
+    }
+  }
+  return targets;
+};
+
+const extractDomTargets = async (
+  document: Document,
+  type:
+    | "TextTargetIntegrity"
+    | "HtmlTargetIntegrity"
+    | "VisibleTextTargetIntegrity",
+  selectors: string[] | undefined,
+): Promise<ExtractedTarget[]> => {
+  const extracted = await Promise.all(
+    uniqueSelectors(selectors).map(async (cssSelector) => {
+      const target = await createIntegrity(
+        "sha256",
+        { type, cssSelector },
+        document,
+      );
+      if (!target?.integrity) {
+        return undefined;
+      }
+      return toExtractedTarget(target.type, target.integrity, cssSelector);
+    }),
+  );
+  return extracted.filter((target) => target !== undefined);
+};
+
+/**
+ * HTML から target integrity を抽出する。セレクタは呼び出し側（CAS または引数）が渡す。
+ * CIP サイト前提の既定セレクタ（`article [itemprop='headline']` 等）は持たない。
+ */
+export const extractTargetsFromHtml = async (
+  htmlContent: string,
+  options: ExtractTargetsOptions = {},
+): Promise<ExtractedTarget[]> => {
+  const document = new JSDOM(htmlContent).window.document;
+
+  const [textTargets, htmlTargets, visibleTextTargets] = await Promise.all([
+    extractDomTargets(document, "TextTargetIntegrity", options.textSelectors),
+    extractDomTargets(document, "HtmlTargetIntegrity", options.htmlSelectors),
+    extractDomTargets(
+      document,
+      "VisibleTextTargetIntegrity",
+      options.visibleTextSelectors,
+    ),
+  ]);
+
+  return [
+    ...textTargets,
+    ...htmlTargets,
+    ...visibleTextTargets,
+    ...extractExternalTargetIntegrities(document, options.externalSelector),
+  ];
+};

--- a/packages/ca-client/src/targets/html.ts
+++ b/packages/ca-client/src/targets/html.ts
@@ -16,8 +16,8 @@ export type ExtractTargetsOptions = {
 };
 
 /**
- * Default selector for ExternalResourceTargetIntegrity when CAS に cssSelector が無く、
- * 引数も省略された場合。呼び出し側の `externalSelector` で上書きできる。
+ * Default selector for ExternalResourceTargetIntegrity when CAS has no
+ * cssSelector and the caller omitted `externalSelector`.
  */
 export const DEFAULT_EXTERNAL_SELECTOR = ".target-integrity";
 
@@ -76,8 +76,8 @@ const extractDomTargets = async (
 };
 
 /**
- * HTML から target integrity を抽出する。セレクタは呼び出し側（CAS または引数）が渡す。
- * CIP サイト前提の既定セレクタ（`article [itemprop='headline']` 等）は持たない。
+ * Extract target integrity from HTML. Selectors come from the caller
+ * (CAS-recorded values or `DetectDriftOptions`); there is no site-specific default.
  */
 export const extractTargetsFromHtml = async (
   htmlContent: string,


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)  
cas-clientに `detectDrift` メソッドを追加しました。  
`@originator-profile/ca-client` の Public API として `detectDrift` を追加しました。  
ビルド後 HTML から target integrity を再計算し、CAS に記録された target とのずれを判定します。

README に利用例が書いてあるので、インターフェースはそこを参照ください。

利用側のイメージ
```ts
const result = await detectDrift({
  html: builtHtml,
  fileName: "ja-JP.hello.cas.json",
  outputDir: "dist/cas",
});
```

本 PR は #471 (`feat-468` / `writeCasFile`) の上に積む stack PR です。

close #469

## 確認手順

(どうやって変更内容を確認した・してほしいか)  
別途Publishして、OPサイトで動作確認予定です。
