### PR TITLE
External Resource Target に cssSelector を追加

### DIFF
--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -253,6 +253,42 @@ test("detectDrift: extracts external resources from non-CIP markup via externalS
   });
 });
 
+test("detectDrift: returns ok when the CAS external target records its cssSelector", async () => {
+  const html = `
+    <main>Body</main>
+    <img class="op-resource" integrity="sha256-img" src="/a.png" />
+  `;
+  const integrity = await extractTextIntegrity(html, "main");
+
+  await withTempDir(async (dir) => {
+    const dest = await writeCasTargets(
+      join(dir, "cas", "external-css-selector.cas.json"),
+      [
+        {
+          type: "TextTargetIntegrity",
+          cssSelector: "main",
+          integrity,
+        },
+        {
+          type: "ExternalResourceTargetIntegrity",
+          cssSelector: ".op-resource",
+          integrity: "sha256-img",
+        },
+      ],
+    );
+
+    await expect(
+      detectDrift({
+        html,
+        filePath: dest,
+      }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
+  });
+});
+
 test("detectDrift: returns cas_missing when the CAS file does not exist", async () => {
   await withTempDir(async (dir) => {
     await mkdir(join(dir, "cas"), { recursive: true });

--- a/packages/ca-client/src/drift/compare.test.ts
+++ b/packages/ca-client/src/drift/compare.test.ts
@@ -13,7 +13,7 @@ const extractTextIntegrity = async (
 ): Promise<string> => {
   const targets = await extractTargetsFromHtml(html, {
     textSelectors: [cssSelector],
-    externalSelector: ":not(*)",
+    externalSelectors: [":not(*)"],
   });
   const integrity = targets[0]?.integrity;
   if (integrity === undefined) {
@@ -273,6 +273,48 @@ test("detectDrift: returns ok when the CAS external target records its cssSelect
           type: "ExternalResourceTargetIntegrity",
           cssSelector: ".op-resource",
           integrity: "sha256-img",
+        },
+      ],
+    );
+
+    await expect(
+      detectDrift({
+        html,
+        filePath: dest,
+      }),
+    ).resolves.toEqual({
+      status: "ok",
+      casFilePath: dest,
+    });
+  });
+});
+
+test("detectDrift: returns ok when the CAS external targets record different cssSelectors", async () => {
+  const html = `
+    <main>Body</main>
+    <img class="img-hero" integrity="sha256-hero" src="/hero.png" />
+    <img class="img-sidebar" integrity="sha256-sidebar" src="/side.png" />
+  `;
+  const integrity = await extractTextIntegrity(html, "main");
+
+  await withTempDir(async (dir) => {
+    const dest = await writeCasTargets(
+      join(dir, "cas", "multiple-external-selectors.cas.json"),
+      [
+        {
+          type: "TextTargetIntegrity",
+          cssSelector: "main",
+          integrity,
+        },
+        {
+          type: "ExternalResourceTargetIntegrity",
+          cssSelector: ".img-hero",
+          integrity: "sha256-hero",
+        },
+        {
+          type: "ExternalResourceTargetIntegrity",
+          cssSelector: ".img-sidebar",
+          integrity: "sha256-sidebar",
         },
       ],
     );

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -192,12 +192,11 @@ const extractOptionsFromCas = (
     "VisibleTextTargetIntegrity",
     options.visibleTextSelector,
   ),
-  externalSelector:
-    options.externalSelector ??
-    casTargets.find(
-      (target) => target.type === "ExternalResourceTargetIntegrity",
-    )?.cssSelector ??
-    DEFAULT_EXTERNAL_SELECTOR,
+  externalSelectors: selectorsForType(
+    casTargets,
+    "ExternalResourceTargetIntegrity",
+    options.externalSelector ?? DEFAULT_EXTERNAL_SELECTOR,
+  ),
 });
 
 export const detectDrift = async (

--- a/packages/ca-client/src/targets/html.test.ts
+++ b/packages/ca-client/src/targets/html.test.ts
@@ -84,10 +84,18 @@ test("extractExternalTargetIntegrities: uses the given selector", () => {
   const document = new JSDOM(html).window.document;
 
   expect(extractExternalTargetIntegrities(document)).toEqual([
-    { type: "ExternalResourceTargetIntegrity", integrity: "sha256-default" },
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-default",
+      cssSelector: DEFAULT_EXTERNAL_SELECTOR,
+    },
   ]);
   expect(extractExternalTargetIntegrities(document, ".my-resource")).toEqual([
-    { type: "ExternalResourceTargetIntegrity", integrity: "sha256-custom" },
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-custom",
+      cssSelector: ".my-resource",
+    },
   ]);
   expect(DEFAULT_EXTERNAL_SELECTOR).toBe(".target-integrity");
 });

--- a/packages/ca-client/src/targets/html.test.ts
+++ b/packages/ca-client/src/targets/html.test.ts
@@ -18,13 +18,13 @@ test("extractTargetsFromHtml: uses the given selector, not CIP itemprop defaults
 
   const fromMain = await extractTargetsFromHtml(html, {
     textSelectors: ["main"],
-    externalSelector: ":not(*)",
+    externalSelectors: [":not(*)"],
   });
   const fromItemprop = await extractTargetsFromHtml(html, {
     textSelectors: [
       "article [itemprop='headline'], article [itemprop='articleBody']",
     ],
-    externalSelector: ":not(*)",
+    externalSelectors: [":not(*)"],
   });
 
   expect(fromMain).toHaveLength(1);
@@ -47,7 +47,7 @@ test("extractTargetsFromHtml: returns empty when the selector matches nothing", 
   expect(
     await extractTargetsFromHtml(html, {
       textSelectors: ["main"],
-      externalSelector: ":not(*)",
+      externalSelectors: [":not(*)"],
     }),
   ).toEqual([]);
 });
@@ -64,7 +64,7 @@ test("extractTargetsFromHtml: matches createIntegrity for TextTargetIntegrity", 
 
   const extracted = await extractTargetsFromHtml(html, {
     textSelectors: [cssSelector],
-    externalSelector: ":not(*)",
+    externalSelectors: [":not(*)"],
   });
 
   expect(extracted).toEqual([
@@ -90,7 +90,24 @@ test("extractExternalTargetIntegrities: uses the given selector", () => {
       cssSelector: DEFAULT_EXTERNAL_SELECTOR,
     },
   ]);
-  expect(extractExternalTargetIntegrities(document, ".my-resource")).toEqual([
+  expect(extractExternalTargetIntegrities(document, [".my-resource"])).toEqual([
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-custom",
+      cssSelector: ".my-resource",
+    },
+  ]);
+  expect(
+    extractExternalTargetIntegrities(document, [
+      DEFAULT_EXTERNAL_SELECTOR,
+      ".my-resource",
+    ]),
+  ).toEqual([
+    {
+      type: "ExternalResourceTargetIntegrity",
+      integrity: "sha256-default",
+      cssSelector: DEFAULT_EXTERNAL_SELECTOR,
+    },
     {
       type: "ExternalResourceTargetIntegrity",
       integrity: "sha256-custom",

--- a/packages/ca-client/src/targets/html.ts
+++ b/packages/ca-client/src/targets/html.ts
@@ -11,8 +11,8 @@ export type ExtractTargetsOptions = {
   textSelectors?: string[];
   htmlSelectors?: string[];
   visibleTextSelectors?: string[];
-  /** CSS selector for ExternalResourceTargetIntegrity elements */
-  externalSelector?: string;
+  /** CSS selectors for ExternalResourceTargetIntegrity elements */
+  externalSelectors?: string[];
 };
 
 /**
@@ -36,23 +36,24 @@ const toExtractedTarget = (
 
 export const extractExternalTargetIntegrities = (
   document: Document,
-  cssSelector: string = DEFAULT_EXTERNAL_SELECTOR,
-): ExtractedTarget[] => {
-  const targets: ExtractedTarget[] = [];
-  for (const element of document.querySelectorAll(cssSelector)) {
-    const integrity = element.getAttribute("integrity");
-    if (integrity && /^sha(256|384|512)-/.test(integrity)) {
-      targets.push(
-        toExtractedTarget(
-          "ExternalResourceTargetIntegrity",
-          integrity,
-          cssSelector,
-        ),
-      );
+  cssSelectors: string[] = [DEFAULT_EXTERNAL_SELECTOR],
+): ExtractedTarget[] =>
+  uniqueSelectors(cssSelectors).flatMap((cssSelector) => {
+    const targets: ExtractedTarget[] = [];
+    for (const element of document.querySelectorAll(cssSelector)) {
+      const integrity = element.getAttribute("integrity");
+      if (integrity && /^sha(256|384|512)-/.test(integrity)) {
+        targets.push(
+          toExtractedTarget(
+            "ExternalResourceTargetIntegrity",
+            integrity,
+            cssSelector,
+          ),
+        );
+      }
     }
-  }
-  return targets;
-};
+    return targets;
+  });
 
 const extractDomTargets = async (
   document: Document,
@@ -102,6 +103,6 @@ export const extractTargetsFromHtml = async (
     ...textTargets,
     ...htmlTargets,
     ...visibleTextTargets,
-    ...extractExternalTargetIntegrities(document, options.externalSelector),
+    ...extractExternalTargetIntegrities(document, options.externalSelectors),
   ];
 };

--- a/packages/ca-client/src/targets/html.ts
+++ b/packages/ca-client/src/targets/html.ts
@@ -42,10 +42,13 @@ export const extractExternalTargetIntegrities = (
   for (const element of document.querySelectorAll(cssSelector)) {
     const integrity = element.getAttribute("integrity");
     if (integrity && /^sha(256|384|512)-/.test(integrity)) {
-      targets.push({
-        type: "ExternalResourceTargetIntegrity",
-        integrity,
-      });
+      targets.push(
+        toExtractedTarget(
+          "ExternalResourceTargetIntegrity",
+          integrity,
+          cssSelector,
+        ),
+      );
     }
   }
   return targets;

--- a/packages/model/src/target/external-resource-target.ts
+++ b/packages/model/src/target/external-resource-target.ts
@@ -4,6 +4,7 @@ import { SubresourceIntegrity } from "../sri";
 export const ExternalResourceTarget = z.looseObject({
   type: z.literal("ExternalResourceTargetIntegrity"),
   integrity: SubresourceIntegrity,
+  cssSelector: z.string().optional().describe("CSS selector"),
 });
 
 export type ExternalResourceTarget = z.infer<typeof ExternalResourceTarget>;

--- a/packages/model/src/target/target-validation.test.ts
+++ b/packages/model/src/target/target-validation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { BasicTarget } from "./basic-target";
+import { ExternalResourceTarget } from "./external-resource-target";
 import { RawTarget } from "./raw-target";
+import { Target } from "./target";
 
 const VALID_INTEGRITY = `sha256-${"A".repeat(43)}=`;
 
@@ -69,5 +71,45 @@ describe("target[].cssSelector バリデーション", () => {
         ).toBe(true);
       });
     }
+  });
+
+  describe("ExternalResourceTarget", () => {
+    test("cssSelector を省略できる", () => {
+      expect(
+        ExternalResourceTarget.safeParse({
+          type: "ExternalResourceTargetIntegrity",
+          integrity: VALID_INTEGRITY,
+        }).success,
+      ).toBe(true);
+    });
+
+    test("cssSelector を保持する", () => {
+      const result = ExternalResourceTarget.safeParse({
+        type: "ExternalResourceTargetIntegrity",
+        integrity: VALID_INTEGRITY,
+        cssSelector: "#hero-image",
+      });
+      expect(result.data?.cssSelector).toBe("#hero-image");
+    });
+
+    test("文字列以外の cssSelector → エラー", () => {
+      expect(
+        ExternalResourceTarget.safeParse({
+          type: "ExternalResourceTargetIntegrity",
+          integrity: VALID_INTEGRITY,
+          cssSelector: 123,
+        }).success,
+      ).toBe(false);
+    });
+
+    test("Target が cssSelector 付きの External Resource Target を受け付ける", () => {
+      const result = Target.safeParse({
+        type: "ExternalResourceTargetIntegrity",
+        integrity: VALID_INTEGRITY,
+        cssSelector: "#hero-image",
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ cssSelector: "#hero-image" });
+    });
   });
 });

--- a/packages/sign/src/integrity/target-integrity.test.ts
+++ b/packages/sign/src/integrity/target-integrity.test.ts
@@ -7,6 +7,7 @@ import {
   fetchHtmlContent,
   fetchTextContent,
   selectByCss,
+  selectByCssOrIntegrity,
   selectByIntegrity,
 } from "./target-integrity";
 
@@ -139,6 +140,26 @@ describe("createIntegrity()", () => {
 
     expect(result).toEqual({
       type: "ExternalResourceTargetIntegrity",
+      integrity: integrityMetadata.toString(),
+    });
+  });
+
+  it("should keep cssSelector for ExternalResourceTargetIntegrity", async () => {
+    const url = "data:text/plain,ok";
+    const integrityMetadata = await createIntegrityMetadata(
+      "sha256",
+      await fetch(url).then((res) => res.arrayBuffer()),
+    );
+
+    expect(
+      await createIntegrity("sha256", {
+        type: "ExternalResourceTargetIntegrity",
+        content: url,
+        cssSelector: "#hero-image",
+      }),
+    ).toEqual({
+      type: "ExternalResourceTargetIntegrity",
+      cssSelector: "#hero-image",
       integrity: integrityMetadata.toString(),
     });
   });
@@ -368,5 +389,61 @@ describe("selectByIntegrity()", () => {
     });
 
     expect(elements).toEqual([]);
+  });
+});
+
+describe("selectByCssOrIntegrity()", () => {
+  const src =
+    "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==";
+
+  beforeEach(() => {
+    document.body.innerHTML = `\
+<img class="hero" integrity="sha256-yyy" src="${src}" />
+<img integrity="sha256-xxx" src="${src}" />
+<img class="hero" src="${src}" />
+`;
+  });
+
+  it("should select elements by CSS selector even if the integrity attribute does not match", () => {
+    const elements = selectByCssOrIntegrity({
+      cssSelector: ".hero",
+      integrity: "sha256-xxx",
+      document,
+    });
+
+    expect(elements).toHaveLength(2);
+    expect(
+      elements.every((element) => element.classList.contains("hero")),
+    ).toBe(true);
+  });
+
+  it("should select elements by the integrity attribute if no CSS selector is provided", () => {
+    const elements = selectByCssOrIntegrity({
+      integrity: "sha256-xxx",
+      document,
+    });
+
+    expect(elements).toHaveLength(1);
+    expect(elements[0].getAttribute("integrity")).toBe("sha256-xxx");
+  });
+
+  it("should throw if the CSS selector has a syntax error", () => {
+    expect(() =>
+      selectByCssOrIntegrity({
+        cssSelector: "[",
+        integrity: "sha256-xxx",
+        document,
+      }),
+    ).toThrow();
+  });
+
+  it("should throw if the CSS selector is an empty string", () => {
+    expect(() =>
+      selectByCssOrIntegrity({
+        cssSelector: "",
+        integrity: "sha256-xxx",
+        document,
+      }),
+    ).toThrow();
   });
 });

--- a/packages/sign/src/integrity/target-integrity.ts
+++ b/packages/sign/src/integrity/target-integrity.ts
@@ -80,6 +80,18 @@ export const selectByIntegrity: ElementSelector = (params) => {
 };
 
 /**
+ * `ExternalResourceTargetIntegrity` の要素位置特定
+ *
+ * `cssSelector` があれば CSS セレクター、なければ `integrity` 属性で特定します。
+ *
+ * @see {@link https://docs.originator-profile.org/opb/content-integrity-descriptor/external-resource/#how-to-identify-element-location}
+ */
+export const selectByCssOrIntegrity: ElementSelector = (params) =>
+  params.cssSelector === undefined
+    ? selectByIntegrity(params)
+    : selectByCss(params);
+
+/**
  * Target Integrity の作成
  *
  * `ExternalResourceTargetIntegrity` で複数のコンテンツが指定された場合、それぞれのハッシュ値がスペース区切りで結合されます。

--- a/packages/verify/e2e/verify-integrity.test.ts
+++ b/packages/verify/e2e/verify-integrity.test.ts
@@ -103,3 +103,41 @@ test("verifyIntegrity() should verify ExternalResourceTargetIntegrity", async fu
 
   expect((await handle.jsonValue()).valid).toBe(true);
 });
+
+test("verifyIntegrity() should verify ExternalResourceTargetIntegrity by cssSelector", async function ({
+  page,
+}) {
+  await page.goto("/");
+
+  const content: Target = {
+    type: "ExternalResourceTargetIntegrity",
+    cssSelector: ".css-selected",
+    integrity: "sha256-P0hnTtzozTl+5h4CpQdOK+5dwpuINHNaZEahrlrNkSQ=",
+  };
+
+  const handle = await page.evaluateHandle(
+    (content) => verifyIntegrity(content),
+    content,
+  );
+
+  expect((await handle.jsonValue()).valid).toBe(true);
+});
+
+test("verifyIntegrity() should not verify ExternalResourceTargetIntegrity if any element matched by cssSelector has a different resource", async function ({
+  page,
+}) {
+  await page.goto("/");
+
+  const content: Target = {
+    type: "ExternalResourceTargetIntegrity",
+    cssSelector: ".css-selected, .css-mixed",
+    integrity: "sha256-P0hnTtzozTl+5h4CpQdOK+5dwpuINHNaZEahrlrNkSQ=",
+  };
+
+  const handle = await page.evaluateHandle(
+    (content) => verifyIntegrity(content),
+    content,
+  );
+
+  expect((await handle.jsonValue()).valid).toBe(false);
+});

--- a/packages/verify/playwright/index.html
+++ b/packages/verify/playwright/index.html
@@ -18,5 +18,14 @@
       alt="test"
       integrity="sha256-P0hnTtzozTl+5h4CpQdOK+5dwpuINHNaZEahrlrNkSQ="
     />
+    <!-- NOTE: 表示すると要素間の空白が body の innerText に入り
+         VisibleTextTargetIntegrity のテストが壊れるため非表示にしている -->
+    <img class="css-selected display-none" src="./test-16x16.webp" alt="a" />
+    <img class="css-selected display-none" src="./test-16x16.webp" alt="b" />
+    <img
+      class="css-mixed display-none"
+      src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+      alt="other"
+    />
   </body>
 </html>

--- a/packages/verify/src/integrity/target-integrity.test.ts
+++ b/packages/verify/src/integrity/target-integrity.test.ts
@@ -6,7 +6,7 @@ import {
   createIntegrityMetadataSet,
   IntegrityMetadataSet,
 } from "websri";
-import { IntegrityFetchFailed } from "./error";
+import { IntegrityFetchFailed, IntegrityVerificationFailed } from "./error";
 import { verifyIntegrity } from "./target-integrity";
 import { IntegrityVerifyResult } from "./types";
 
@@ -179,5 +179,136 @@ describe("verifyIntegrity()", () => {
 
     expect(result instanceof Error).toBe(true);
     expect(result).toBeInstanceOf(IntegrityFetchFailed);
+  });
+
+  describe("cssSelector for ExternalResourceTargetIntegrity", () => {
+    const sriOf = async (content: string) =>
+      (
+        await createIntegrityMetadata(
+          "sha256",
+          await new Response(content).arrayBuffer(),
+        )
+      ).toString();
+
+    it("should verify the element matching the CSS selector without an integrity attribute", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img class="hero" src="data:text/plain,ok" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: ".hero",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      expect((fetchResult as IntegrityVerifyResult).valid).toBe(true);
+    });
+
+    it("should prefer the CSS selector over the integrity attribute", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img class="hero" src="data:text/plain,ok" />
+<img integrity="${integrity}" src="data:text/plain,ng" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: ".hero",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      expect((fetchResult as IntegrityVerifyResult).valid).toBe(true);
+    });
+
+    it("should return true when every element matching the CSS selector matches the integrity", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img class="logo" src="data:text/plain,ok" />
+<img class="logo" src="data:text/plain,ok" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: ".logo",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      expect((fetchResult as IntegrityVerifyResult).valid).toBe(true);
+    });
+
+    it("should return false when any element matching the CSS selector does not match the integrity", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img class="logo" src="data:text/plain,ok" />
+<img class="logo" src="data:text/plain,ng" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: ".logo",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      const verifyResult = fetchResult as IntegrityVerifyResult;
+      expect(verifyResult.valid).toBe(false);
+      expect(verifyResult.failedIntegrities).toEqual([await sriOf("ng")]);
+    });
+
+    it("should return false when any element matching the integrity attribute does not match the integrity", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img integrity="${integrity}" src="data:text/plain,ok" />
+<img integrity="${integrity}" src="data:text/plain,ng" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      const verifyResult = fetchResult as IntegrityVerifyResult;
+      expect(verifyResult.valid).toBe(false);
+      expect(verifyResult.failedIntegrities).toEqual([await sriOf("ng")]);
+    });
+
+    it("should return false if no elements match the CSS selector", async () => {
+      const integrity = await sriOf("ok");
+
+      document.body.innerHTML = `\
+<img integrity="${integrity}" src="data:text/plain,ok" />
+`;
+
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: ".non-existent",
+        integrity,
+      });
+
+      expect(fetchResult instanceof Error).toBe(false);
+      const verifyResult = fetchResult as IntegrityVerifyResult;
+      expect(verifyResult.valid).toBe(false);
+      expect(verifyResult.failedIntegrities).toEqual([]);
+    });
+
+    it("should return IntegrityVerificationFailed if the CSS selector has a syntax error", async () => {
+      const fetchResult = await verifyIntegrity({
+        type: "ExternalResourceTargetIntegrity",
+        cssSelector: "[",
+        integrity: await sriOf("ok"),
+      });
+
+      expect(fetchResult).toBeInstanceOf(IntegrityVerificationFailed);
+    });
   });
 });

--- a/packages/verify/src/integrity/target-integrity.ts
+++ b/packages/verify/src/integrity/target-integrity.ts
@@ -8,7 +8,7 @@ import {
   fetchTextContent,
   fetchVisibleTextContent,
   selectByCss,
-  selectByIntegrity,
+  selectByCssOrIntegrity,
 } from "@originator-profile/sign";
 import { createIntegrityMetadataSet, IntegrityMetadataSet } from "websri";
 import { IntegrityFetchFailed, IntegrityVerificationFailed } from "./error";
@@ -67,7 +67,7 @@ export const TargetIntegrityAlgorithm = {
   },
   ExternalResourceTargetIntegrity: {
     contentFetcher: fetchExternalResource,
-    elementSelector: selectByIntegrity,
+    elementSelector: selectByCssOrIntegrity,
   },
 };
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -169,11 +169,21 @@ Entries without `main: true` are serialized as bare JWT strings. Entries with `m
 
 ## Limitations
 
-### `ExternalResourceTargetIntegrity` requires manual `integrity` attribute
+### `ExternalResourceTargetIntegrity` requires `cssSelector` or a manual `integrity` attribute
 
-When using [`ExternalResourceTargetIntegrity`](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/external-resource/), verifiers [locate target elements by matching the `integrity` HTML attribute](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/external-resource/#how-to-identify-element-location). This plugin computes the `integrity` value and includes it in the signed CA, but **does not** automatically add the `integrity` attribute to the corresponding HTML elements.
+When using [`ExternalResourceTargetIntegrity`](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/external-resource/), verifiers [locate target elements by the `cssSelector` property, and fall back to matching the `integrity` HTML attribute when it is absent](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/external-resource/#how-to-identify-element-location). This plugin computes the `integrity` value and includes it in the signed CA, but **does not** automatically add the `integrity` attribute to the corresponding HTML elements.
 
-You must manually set the `integrity` attribute on each `<img>`, `<source>`, or other resource element to match the signed value:
+Set `cssSelector` on the target so that it matches the resource element. Every element it matches must reference a resource matching the signed `integrity`, otherwise verification fails.
+
+```json
+{
+  "type": "ExternalResourceTargetIntegrity",
+  "cssSelector": "#hero-image",
+  "content": "https://example.com/image.png"
+}
+```
+
+Without `cssSelector`, you must manually set the `integrity` attribute on each `<img>`, `<source>`, or other resource element to match the signed value:
 
 ```html
 <img src="https://example.com/image.png" integrity="sha256-..." />


### PR DESCRIPTION
## 変更内容

[docs.originator-profile.org#520](https://github.com/originator-profile/docs.originator-profile.org/pull/520) で External Resource Target (`ExternalResourceTargetIntegrity`) に `cssSelector` プロパティ (OPTIONAL) が追加された仕様変更を実装に反映します。

反映する規範:

- `cssSelector` がある場合、その CSS セレクターを `querySelectorAll()` で評価して検証対象要素を特定する
- `cssSelector` がない場合、従来どおり `integrity` プロパティと同じ値の `integrity` HTML 属性の完全一致で特定する (後方互換)
- 両方ある場合は `cssSelector` が優先される
- マッチしたすべての要素に対応するリソースが `integrity` と一致しなければならない (MUST)。1 つでも一致しないリソースがあれば検証失敗 (MUST)
- `cssSelector` の構文エラー、および要素 0 件は検証失敗として扱うことがある (MAY)

既存の CA (= `cssSelector` なし) の解釈は変わりません。

### パッケージごとの変更

| パッケージ | 変更 |
| --- | --- |
| `model` | `ExternalResourceTarget` に `cssSelector: z.string().optional()` を追加 |
| `sign` | `cssSelector` 優先で要素を特定する `selectByCssOrIntegrity` を追加 |
| `verify` | `TargetIntegrityAlgorithm` の External の `elementSelector` を差し替え |
| `ca-client` | 抽出結果に `cssSelector` を残し、複数の `cssSelector` に対応 (drift 誤検出の修正 2 件) |
| `vite-plugin` | README の Limitations を更新 (コード変更なし) |

### 設計判断

**`selectByIntegrity` を書き換えず新しい `ElementSelector` を追加した**

`selectByIntegrity` は `@originator-profile/sign` の公開 API です。「`integrity` 属性で選ぶ」という意味を黙って変えないため、`selectByCssOrIntegrity` を新設して `TargetIntegrityAlgorithm` の割当だけを差し替えました。

**分岐を `IntegrityVerifier` ではなく `ElementSelector` 側に置いた**

`apps/inspector` の `content-script-all-frames.ts` と `overlay/use-elements.ts` が `TargetIntegrityAlgorithm[type].elementSelector` を直接呼んでハイライト位置を決めています。分岐を `IntegrityVerifier` に置くと検証結果とハイライト位置が食い違い、分岐も二重化します。selector 内に置いたことで inspector は無改修で追随します。

**`cssSelector` の判定を `=== undefined` にした**

空文字を `integrity` 属性経路に黙って落とさず、`querySelectorAll("")` の構文エラー → 検証失敗にするためです。仕様上、CSS セレクターの構文エラーは検証失敗として扱えます。特別扱いのコードが不要になります。

**複数マッチ時の MUST は実装変更なし**

`fetchExternalResource` は要素ごとに Response を返し、`IntegrityVerifier` は全 Response を照合して 1 件でも外れれば `valid: false` にします。仕様の MUST は既存ロジックで満たされていました。テストが 1 本もなかったため、`cssSelector` 経路と `integrity` 属性経路の両方に回帰テストを追加しています。

**`ca-client` の修正を同一 PR に含めた理由**

`areTargetsEqual` は CAS 側に `cssSelector` があれば一致を要求し、`extractOptionsFromCas` は CAS 側の `cssSelector` を抽出セレクターの取得元として既に読んでいました。一方 `extractExternalTargetIntegrities` だけが抽出に使った `cssSelector` を結果に落としていたため、**`cssSelector` を持つ CA を発行した瞬間に `detectDrift` が常に `drifted` と誤判定します**。本 PR が新規に到達可能にする破壊なので同じ PR で塞ぎました。CAS 側に `cssSelector` がない既存データは従来どおり比較がスキップされます。

さらに `extractOptionsFromCas` は CAS から**最初の** External Resource Target の `cssSelector` しか読んでいなかったため、異なる `cssSelector` を持つ target が複数ある CAS では 2 つ目以降の要素が抽出されず必ず `drifted` になります。仕様は要素ごとに異なる `cssSelector` を指定する使い方 (`#hero-image-source` と `#hero-image` など) を示しているため、`cssSelector` に対応した以上は実際に踏みます。テキスト系 target と同じ `selectorsForType` を使うよう揃えました。

この変更で `externalSelector` オプションと CAS の `cssSelector` の優先順位もテキスト系と揃い、**CAS に記録された値が優先されます** (従来は `externalSelector` が優先)。`extractTargetsFromHtml` / `ExtractTargetsOptions` / `extractExternalTargetIntegrities` はいずれも `ca-client` の公開 API ではないため、`DetectDriftOptions.externalSelector` は単数のまま変わりません。

### 今回のスコープ外

- **WordPress / cas-generator の発行側**: `includes/post.php` が `<img>` に `integrity` 属性を注入して辻褄を合わせており、`cas-generator` も `.target-integrity` の属性を読む方式で動き続けるため、現行実装を踏襲しました。
- **inspector のセレクター構文エラー対策**: `content-script-all-frames.ts` と `overlay/use-elements.ts` が `elementSelector` を try/catch なしで呼ぶため、不正なセレクター 1 件でオーバーレイ全体が落ちます。`BasicTarget.cssSelector` (REQUIRED) で既に到達可能な既存不具合で、原因も修正も本仕様変更とは独立するため別 PR とします。

### 注意事項

- **JSON-LD context tag の更新が別途必要です。** `https://originator-profile.org/ns/cip/v1` の実体はこのリポジトリに存在せず、`"cssSelector": "https://schema.org/cssSelector"` の追加は別リポジトリでの対応になります。`@protected` のため、配信 context が更新されるまで `cssSelector` を含む CA は JSON-LD 処理で失敗します。docs 側 PR とリリースタイミングを揃える必要があります。
- **ロールアウト制約**: 旧検証器は `[integrity=...]` でしか要素を引けないため、検証器が行き渡るまで発行側は `cssSelector` 単独 (`integrity` 属性なし) の External Resource Target を出すべきではありません。

## 確認手順

```console
pnpm test
pnpm lint
pnpm exec prettier --check .
pnpm --filter @originator-profile/verify e2e
```

手元での結果:

- `pnpm test` — 25 タスク全成功
- `pnpm lint` — 0 warnings / 0 errors
- `pnpm exec prettier --check` — 変更ファイルすべて通過
- E2E — chromium / firefox / webkit で 18 件全通過

E2E フィクスチャに追加した `<img>` は `display: none` にしています。表示すると要素間の空白が `body.innerText` に入り `VisibleTextTargetIntegrity` のテストが壊れるためです。非表示でも `currentSrc` は解決されるため、要素特定とリソース取得の検証には影響しません。意図は HTML 内のコメントに残しています。

`ca-client` の修正については、修正を一時的に戻すと追加した回帰テスト (`detectDrift: returns ok when the CAS external target records its cssSelector`) が実際に失敗することを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LErtGn5FhUez8HTbaoYL6J


