### PR TITLE
e2e テストにて issuer と holder を分けて指定できるように修正

### DIFF
--- a/apps/inspector/e2e/advertorial-content-attestation.test.ts
+++ b/apps/inspector/e2e/advertorial-content-attestation.test.ts
@@ -20,12 +20,16 @@ test("Advertorial Content Attestation の表示が正しく行われているこ
   validCas,
   credentialsPage,
 }) => {
-  await validOps({ publicKey, privateKey }, credentialsPage.issuer);
+  await validOps(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
 
   await validCas(
     { privateKey },
     credentialsPage.contents,
-    credentialsPage.issuer,
+    credentialsPage.holder,
     "Advertorial",
   );
 

--- a/apps/inspector/e2e/cas.test.ts
+++ b/apps/inspector/e2e/cas.test.ts
@@ -26,6 +26,7 @@ test("Content Attestation Set の表示が正常に行えたか", async ({
     { publicKey, privateKey },
     credentialsPage.contents,
     credentialsPage.issuer,
+    credentialsPage.holder,
   );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);

--- a/apps/inspector/e2e/content-attestation-highlight.test.ts
+++ b/apps/inspector/e2e/content-attestation-highlight.test.ts
@@ -21,8 +21,13 @@ test("拡張機能画面での認証および対象ページのオーバーレ�
   credentialsPage,
 }) => {
   const key = { privateKey, publicKey };
-  await validSiteProfile(key, credentialsPage.issuer);
-  await validCredentials(key, credentialsPage.contents, credentialsPage.issuer);
+  await validSiteProfile(key, credentialsPage.issuer, credentialsPage.holder);
+  await validCredentials(
+    key,
+    credentialsPage.contents,
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
 

--- a/apps/inspector/e2e/credentials-fixtures.ts
+++ b/apps/inspector/e2e/credentials-fixtures.ts
@@ -21,6 +21,7 @@ type TestFixtures = {
     key: { publicKey: Jwk; privateKey: Jwk },
     contents: string,
     issuer: string,
+    holder: string,
   ) => Promise<void>;
   missingCredentials: void;
   validCas: (
@@ -32,12 +33,17 @@ type TestFixtures = {
   validOps: (
     key: { publicKey: Jwk; privateKey: Jwk },
     issuer: string,
+    holder: string,
   ) => Promise<void>;
   invalidCas: void;
   missingCas: void;
   evilCas: (contents: string, issuer: string) => Promise<void>;
   missingOps: void;
-  evilOps: (key: { publicKey: Jwk }, issuer: string) => Promise<void>;
+  evilOps: (
+    key: { publicKey: Jwk },
+    issuer: string,
+    holder: string,
+  ) => Promise<void>;
 };
 
 const casEndpoint: string = "http://localhost:8080/examples/cas.json";
@@ -50,12 +56,13 @@ export const test = base.extend<TestFixtures>({
         key: { publicKey: Jwk; privateKey: Jwk },
         contents: string,
         issuer: string,
+        holder: string,
       ) => {
         const { publicKey, privateKey } = key;
         const issuedAt: Date = new Date(Date.now());
         const expiredAt: Date = addYears(new Date(), 1);
         const unsignedContentAttestation: UnsignedContentAttestation =
-          generateUnsignedContentAttestation(contents, issuer);
+          generateUnsignedContentAttestation(contents, holder);
         const contentAttestation = await signCa(
           unsignedContentAttestation,
           privateKey,
@@ -71,7 +78,7 @@ export const test = base.extend<TestFixtures>({
         );
 
         const signedCoreProfile = await signJwtVc(
-          generateCoreProfileData(publicKey, issuer),
+          generateCoreProfileData(publicKey, issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -79,7 +86,7 @@ export const test = base.extend<TestFixtures>({
           },
         );
         const annotations = await signJwtVc(
-          generateCertificateData(issuer),
+          generateCertificateData(issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -87,7 +94,7 @@ export const test = base.extend<TestFixtures>({
           },
         );
         const signedMediaProfile = await signJwtVc(
-          generateWebMediaProfileData(issuer),
+          generateWebMediaProfileData(issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -185,12 +192,16 @@ export const test = base.extend<TestFixtures>({
   },
   validOps: async ({ page }: { page: Page }, use) => {
     await use(
-      async (key: { publicKey: Jwk; privateKey: Jwk }, issuer: string) => {
+      async (
+        key: { publicKey: Jwk; privateKey: Jwk },
+        issuer: string,
+        holder: string,
+      ) => {
         const { publicKey, privateKey } = key;
         const issuedAt: Date = new Date(Date.now());
         const expiredAt: Date = addYears(new Date(), 1);
         const signedCoreProfile = await signJwtVc(
-          generateCoreProfileData(publicKey, issuer),
+          generateCoreProfileData(publicKey, issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -198,7 +209,7 @@ export const test = base.extend<TestFixtures>({
           },
         );
         const annotations = await signJwtVc(
-          generateCertificateData(issuer),
+          generateCertificateData(issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -206,7 +217,7 @@ export const test = base.extend<TestFixtures>({
           },
         );
         const signedMediaProfile = await signJwtVc(
-          generateWebMediaProfileData(issuer),
+          generateWebMediaProfileData(issuer, holder),
           privateKey,
           {
             issuedAt,
@@ -224,10 +235,9 @@ export const test = base.extend<TestFixtures>({
             contentType: "application/json",
           }),
         );
-
-        await page.unroute(opsEndpoint);
       },
     );
+    await page.unroute(opsEndpoint);
   },
   invalidCas: async ({ page }: { page: Page }, use) => {
     const cas: ContentAttestationSet = [
@@ -306,48 +316,50 @@ export const test = base.extend<TestFixtures>({
     await page.unroute(opsEndpoint);
   },
   evilOps: async ({ page }: { page: Page }, use) => {
-    await use(async (key: { publicKey: Jwk }, issuer: string) => {
-      const { publicKey } = key;
-      const { privateKey } = await generateKey();
-      const issuedAt: Date = new Date(Date.now());
-      const expiredAt: Date = addYears(new Date(), 1);
-      const signedCoreProfile = await signJwtVc(
-        generateCoreProfileData(publicKey, issuer),
-        privateKey,
-        {
-          issuedAt,
-          expiredAt,
-        },
-      );
-      const annotations = await signJwtVc(
-        generateCertificateData(issuer),
-        privateKey,
-        {
-          issuedAt,
-          expiredAt,
-        },
-      );
-      const signedMediaProfile = await signJwtVc(
-        generateWebMediaProfileData(issuer),
-        privateKey,
-        {
-          issuedAt,
-          expiredAt,
-        },
-      );
+    await use(
+      async (key: { publicKey: Jwk }, issuer: string, holder: string) => {
+        const { publicKey } = key;
+        const { privateKey } = await generateKey();
+        const issuedAt: Date = new Date(Date.now());
+        const expiredAt: Date = addYears(new Date(), 1);
+        const signedCoreProfile = await signJwtVc(
+          generateCoreProfileData(publicKey, issuer, holder),
+          privateKey,
+          {
+            issuedAt,
+            expiredAt,
+          },
+        );
+        const annotations = await signJwtVc(
+          generateCertificateData(issuer, holder),
+          privateKey,
+          {
+            issuedAt,
+            expiredAt,
+          },
+        );
+        const signedMediaProfile = await signJwtVc(
+          generateWebMediaProfileData(issuer, holder),
+          privateKey,
+          {
+            issuedAt,
+            expiredAt,
+          },
+        );
 
-      await page.route(opsEndpoint, async (route) =>
-        route.fulfill({
-          body: JSON.stringify({
-            core: signedCoreProfile,
-            annotations: [annotations],
-            media: signedMediaProfile,
+        await page.route(opsEndpoint, async (route) =>
+          route.fulfill({
+            body: JSON.stringify({
+              core: signedCoreProfile,
+              annotations: [annotations],
+              media: signedMediaProfile,
+            }),
+            contentType: "application/json",
           }),
-          contentType: "application/json",
-        }),
-      );
+        );
 
-      //await page.unroute(opsEndpoint);
-    });
+        //await page.unroute(opsEndpoint);
+      },
+    );
   },
 });

--- a/apps/inspector/e2e/credentials-fixtures.ts
+++ b/apps/inspector/e2e/credentials-fixtures.ts
@@ -357,8 +357,6 @@ export const test = base.extend<TestFixtures>({
             contentType: "application/json",
           }),
         );
-
-        //await page.unroute(opsEndpoint);
       },
     );
   },

--- a/apps/inspector/e2e/credentials-prohibition.test.ts
+++ b/apps/inspector/e2e/credentials-prohibition.test.ts
@@ -23,7 +23,11 @@ test("CASの検証に失敗した場合に閲覧禁止が表示されるか", as
   validOps,
   credentialsPage,
 }) => {
-  await validOps({ publicKey, privateKey }, credentialsPage.issuer);
+  await validOps(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
@@ -42,8 +46,12 @@ test("CAの署名がその発行者のOPで配布される検証鍵を使って�
   evilCas: evilCas,
   credentialsPage,
 }) => {
-  await evilCas(credentialsPage.contents, credentialsPage.issuer);
-  await validOps({ publicKey, privateKey }, credentialsPage.issuer);
+  await evilCas(credentialsPage.contents, credentialsPage.holder);
+  await validOps(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
@@ -65,9 +73,13 @@ test("OPの署名がその発行者のOPで配布される検証鍵を使って�
   await validCas(
     { privateKey },
     credentialsPage.contents,
-    credentialsPage.issuer,
+    credentialsPage.holder,
   );
-  await evilOps({ publicKey: publicKey }, credentialsPage.issuer);
+  await evilOps(
+    { publicKey: publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
@@ -88,8 +100,12 @@ test("OPとCAの署名がその発行者のOPで配布される検証鍵を使�
   evilCas: evilCas,
   credentialsPage,
 }) => {
-  await evilCas(credentialsPage.contents, credentialsPage.issuer);
-  await evilOps({ publicKey: publicKey }, credentialsPage.issuer);
+  await evilCas(credentialsPage.contents, credentialsPage.holder);
+  await evilOps(
+    { publicKey: publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
@@ -115,7 +131,11 @@ test("CAのissuerが適切でない場合閲覧禁止", async ({
     credentialsPage.contents,
     "incorrectIssuer",
   );
-  await validOps({ publicKey, privateKey }, credentialsPage.issuer);
+  await validOps(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();

--- a/apps/inspector/e2e/data.ts
+++ b/apps/inspector/e2e/data.ts
@@ -10,6 +10,7 @@ import type {
 export function generateCoreProfileData(
   publicKey: Jwk,
   issuer: string = "dns:localhost",
+  holder: string = "dns:op-holder.example.com",
 ): CoreProfile {
   return {
     "@context": [
@@ -19,7 +20,7 @@ export function generateCoreProfileData(
     type: ["VerifiableCredential", "CoreProfile"],
     issuer: issuer,
     credentialSubject: {
-      id: issuer,
+      id: holder,
       type: "Core",
       jwks: {
         keys: [publicKey],
@@ -30,6 +31,7 @@ export function generateCoreProfileData(
 
 export function generateCertificateData(
   issuer: string = "dns:localhost",
+  holder: string = "dns:op-holder.example.com",
 ): Certificate {
   return {
     "@context": [
@@ -43,7 +45,7 @@ export function generateCertificateData(
     type: ["VerifiableCredential", "Certificate"],
     issuer: issuer,
     credentialSubject: {
-      id: issuer,
+      id: holder,
       type: "CertificateProperties",
       description: "Example Certificate",
       certificationSystem: {
@@ -58,6 +60,7 @@ export function generateCertificateData(
 
 export function generateWebMediaProfileData(
   issuer: string = "dns:localhost",
+  holder: string = "dns:op-holder.example.com",
 ): WebMediaProfile {
   return {
     "@context": [
@@ -71,7 +74,7 @@ export function generateWebMediaProfileData(
     type: ["VerifiableCredential", "WebMediaProfile"],
     issuer: issuer,
     credentialSubject: {
-      id: issuer,
+      id: holder,
       type: "OnlineBusiness",
       name: "Originator Profile 技術研究組合 (開発用)",
       url: "http://localhost:8080",

--- a/apps/inspector/e2e/online-ad-content-attestation.test.ts
+++ b/apps/inspector/e2e/online-ad-content-attestation.test.ts
@@ -20,13 +20,17 @@ test("OnlineAd Content Attestation の表示が正しく行われていること
   validCas,
   onlineAdPage,
 }) => {
-  await validOps({ publicKey, privateKey }, onlineAdPage.issuer);
+  await validOps(
+    { publicKey, privateKey },
+    onlineAdPage.issuer,
+    onlineAdPage.holder,
+  );
 
   // OnlineAd Content Attestationを署名
   await validCas(
     { privateKey },
     onlineAdPage.contents,
-    onlineAdPage.issuer,
+    onlineAdPage.holder,
     "OnlineAd",
   );
 

--- a/apps/inspector/e2e/site-profile-and-cas-missing.test.ts
+++ b/apps/inspector/e2e/site-profile-and-cas-missing.test.ts
@@ -23,7 +23,11 @@ test("Site Profile と CAS が取得できない場合Unsuportedが表示され�
   validOps,
   credentialsPage,
 }) => {
-  await validOps({ publicKey, privateKey }, credentialsPage.issuer);
+  await validOps(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-unsupported-message")).toBeVisible();

--- a/apps/inspector/e2e/site-profile-and-cas.test.ts
+++ b/apps/inspector/e2e/site-profile-and-cas.test.ts
@@ -23,11 +23,15 @@ test("SiteProfile/CASの検証に成功するが、htmlに記載されたOPSの�
   missingOps: _,
   credentialsPage,
 }) => {
-  await validSiteProfile({ privateKey, publicKey }, credentialsPage.issuer);
+  await validSiteProfile(
+    { privateKey, publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await validCas(
     { privateKey },
     credentialsPage.contents,
-    credentialsPage.issuer,
+    credentialsPage.holder,
   );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
@@ -55,11 +59,12 @@ test("CASの検証に成功するが、SiteProfileのWMPの取得に失敗した
   await missingMediaSiteProfile(
     { privateKey, publicKey },
     credentialsPage.issuer,
+    credentialsPage.holder,
   );
   await validCas(
     { privateKey },
     credentialsPage.contents,
-    credentialsPage.issuer,
+    credentialsPage.holder,
   );
 
   await page.goto(credentialsPage.endpoint);

--- a/apps/inspector/e2e/site-profile-different-key.test.ts
+++ b/apps/inspector/e2e/site-profile-different-key.test.ts
@@ -23,9 +23,18 @@ test("異なる鍵ペアによる署名のとき検証失敗", async ({
   credentialsPage,
   validCredentials,
 }) => {
-  await validSiteProfile({ privateKey, publicKey }, credentialsPage.issuer);
+  await validSiteProfile(
+    { privateKey, publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   const key = await generateKey();
-  await validCredentials(key, credentialsPage.contents, credentialsPage.issuer);
+  await validCredentials(
+    key,
+    credentialsPage.contents,
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
 
   const ext = await sidepanel(context);

--- a/apps/inspector/e2e/site-profile-fixtures.ts
+++ b/apps/inspector/e2e/site-profile-fixtures.ts
@@ -83,8 +83,10 @@ async function createSiteProfile(
   };
 
   if (includeMedia) {
-    const webMediaProfile: WebMediaProfile =
-      generateWebMediaProfileData(issuer, holder);
+    const webMediaProfile: WebMediaProfile = generateWebMediaProfileData(
+      issuer,
+      holder,
+    );
     const signedMediaProfile = await signJwtVc(webMediaProfile, privateKey, {
       issuedAt,
       expiredAt,

--- a/apps/inspector/e2e/site-profile-fixtures.ts
+++ b/apps/inspector/e2e/site-profile-fixtures.ts
@@ -22,21 +22,29 @@ type TestFixtures = {
   validSiteProfile: (
     key: { publicKey: Jwk; privateKey: Jwk },
     issuer: string,
+    holder: string,
   ) => Promise<void>;
   invalidSiteProfile: void;
   missingSiteProfile: void;
-  evilSiteProfile: (key: { publicKey: Jwk }, issuer: string) => Promise<void>;
+  evilSiteProfile: (
+    key: { publicKey: Jwk },
+    issuer: string,
+    holder: string,
+  ) => Promise<void>;
   missingMediaSiteProfile: (
     key: { publicKey: Jwk; privateKey: Jwk },
     issuer: string,
+    holder: string,
   ) => Promise<void>;
   expiringSoonSiteProfile: (
     key: { publicKey: Jwk; privateKey: Jwk },
     issuer: string,
+    holder: string,
   ) => Promise<void>;
   multiLocaleSiteProfile: (
     key: { publicKey: Jwk; privateKey: Jwk },
     issuer: string,
+    holder: string,
   ) => Promise<void>;
 };
 
@@ -47,15 +55,20 @@ const WELL_KKNOWN_SP_URL = "http://localhost:8080/.well-known/sp.json";
 async function createSiteProfile(
   key: KeyPair,
   issuer: string,
+  holder: string,
   includeMedia: boolean = true,
   expiredAt: Date = addYears(new Date(), 1),
 ): Promise<SiteProfile> {
   const { publicKey, privateKey } = key;
   const issuedAt: Date = new Date(Date.now());
 
-  const coreProfile: CoreProfile = generateCoreProfileData(publicKey, issuer);
-  const certificate: Certificate = generateCertificateData(issuer);
-  const websiteProfile: WebsiteProfile = generateWebsiteProfileData(issuer);
+  const coreProfile: CoreProfile = generateCoreProfileData(
+    publicKey,
+    issuer,
+    holder,
+  );
+  const certificate: Certificate = generateCertificateData(issuer, holder);
+  const websiteProfile: WebsiteProfile = generateWebsiteProfileData(holder);
   const signedCoreProfile = await signJwtVc(coreProfile, privateKey, {
     issuedAt,
     expiredAt,
@@ -71,7 +84,7 @@ async function createSiteProfile(
 
   if (includeMedia) {
     const webMediaProfile: WebMediaProfile =
-      generateWebMediaProfileData(issuer);
+      generateWebMediaProfileData(issuer, holder);
     const signedMediaProfile = await signJwtVc(webMediaProfile, privateKey, {
       issuedAt,
       expiredAt,
@@ -114,8 +127,12 @@ async function cleanupRoute(page: Page) {
 export const test = base.extend<TestFixtures>({
   validSiteProfile: async ({ page }: { page: Page }, use) => {
     await use(
-      async (key: { publicKey: Jwk; privateKey: Jwk }, issuer: string) => {
-        const sp: SiteProfile = await createSiteProfile(key, issuer);
+      async (
+        key: { publicKey: Jwk; privateKey: Jwk },
+        issuer: string,
+        holder: string,
+      ) => {
+        const sp: SiteProfile = await createSiteProfile(key, issuer, holder);
         await setupRoute(page, sp, 200);
       },
     );
@@ -145,23 +162,35 @@ export const test = base.extend<TestFixtures>({
     await cleanupRoute(page);
   },
   evilSiteProfile: async ({ page }: { page: Page }, use) => {
-    await use(async (key: { publicKey: Jwk }, issuer: string) => {
-      const { publicKey } = key;
-      const { privateKey } = await generateKey();
-      const sp: SiteProfile = await createSiteProfile(
-        { publicKey, privateKey },
-        issuer,
-      );
+    await use(
+      async (key: { publicKey: Jwk }, issuer: string, holder: string) => {
+        const { publicKey } = key;
+        const { privateKey } = await generateKey();
+        const sp: SiteProfile = await createSiteProfile(
+          { publicKey, privateKey },
+          issuer,
+          holder,
+        );
 
-      await setupRoute(page, sp, 200);
-    });
+        await setupRoute(page, sp, 200);
+      },
+    );
 
     await cleanupRoute(page);
   },
   missingMediaSiteProfile: async ({ page }: { page: Page }, use) => {
     await use(
-      async (key: { publicKey: Jwk; privateKey: Jwk }, issuer: string) => {
-        const sp: SiteProfile = await createSiteProfile(key, issuer, false);
+      async (
+        key: { publicKey: Jwk; privateKey: Jwk },
+        issuer: string,
+        holder: string,
+      ) => {
+        const sp: SiteProfile = await createSiteProfile(
+          key,
+          issuer,
+          holder,
+          false,
+        );
 
         await setupRoute(page, sp, 200);
       },
@@ -171,10 +200,15 @@ export const test = base.extend<TestFixtures>({
   },
   expiringSoonSiteProfile: async ({ page }: { page: Page }, use) => {
     await use(
-      async (key: { publicKey: Jwk; privateKey: Jwk }, issuer: string) => {
+      async (
+        key: { publicKey: Jwk; privateKey: Jwk },
+        issuer: string,
+        holder: string,
+      ) => {
         const sp: SiteProfile = await createSiteProfile(
           key,
           issuer,
+          holder,
           true,
           addDays(new Date(), 1),
         );
@@ -187,7 +221,11 @@ export const test = base.extend<TestFixtures>({
   },
   multiLocaleSiteProfile: async ({ page }: { page: Page }, use) => {
     await use(
-      async (key: { publicKey: Jwk; privateKey: Jwk }, issuer: string) => {
+      async (
+        key: { publicKey: Jwk; privateKey: Jwk },
+        issuer: string,
+        holder: string,
+      ) => {
         const { publicKey, privateKey } = key;
         const issuedAt: Date = new Date(Date.now());
         const expiredAt: Date = addYears(new Date(), 1);
@@ -195,8 +233,12 @@ export const test = base.extend<TestFixtures>({
         const coreProfile: CoreProfile = generateCoreProfileData(
           publicKey,
           issuer,
+          holder,
         );
-        const certificate: Certificate = generateCertificateData(issuer);
+        const certificate: Certificate = generateCertificateData(
+          issuer,
+          holder,
+        );
         const signedCoreProfile = await signJwtVc(coreProfile, privateKey, {
           issuedAt,
           expiredAt,
@@ -207,8 +249,10 @@ export const test = base.extend<TestFixtures>({
         });
 
         // 複数言語のWebMediaProfileを作成
-        const webMediaProfileJa: WebMediaProfile =
-          generateWebMediaProfileData(issuer);
+        const webMediaProfileJa: WebMediaProfile = generateWebMediaProfileData(
+          issuer,
+          holder,
+        );
         const webMediaProfileEn: WebMediaProfile = {
           ...webMediaProfileJa,
           "@context": [
@@ -250,7 +294,7 @@ export const test = base.extend<TestFixtures>({
 
         // 複数言語のWebsiteProfileを作成
         const websiteProfileJa: WebsiteProfile =
-          generateWebsiteProfileData(issuer);
+          generateWebsiteProfileData(holder);
         const websiteProfileEn: WebsiteProfile = {
           ...websiteProfileJa,
           "@context": [

--- a/apps/inspector/e2e/site-profile-locale.test.ts
+++ b/apps/inspector/e2e/site-profile-locale.test.ts
@@ -23,6 +23,7 @@ test("複数ロケールのSite Profile - 日本語ロケールで日本語コ�
   await multiLocaleSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -56,6 +57,7 @@ test("複数ロケールのSite Profile - 英語ロケールで英語コンテ�
   await multiLocaleSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -91,6 +93,7 @@ test("複数ロケールのSite Profile - 未対応ロケールで英語フォ�
   await multiLocaleSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);

--- a/apps/inspector/e2e/site-profile-prohibition-with-credentials.test.ts
+++ b/apps/inspector/e2e/site-profile-prohibition-with-credentials.test.ts
@@ -26,6 +26,7 @@ test("CAS/OPSの取得に成功するがSPの検証に失敗した場合閲覧�
     { publicKey, privateKey },
     credentialsPage.contents,
     credentialsPage.issuer,
+    credentialsPage.holder,
   );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
@@ -56,8 +57,12 @@ test("CAの署名がその発行者のSPで配布される検証鍵を使って�
   evilCas: evilCas,
   credentialsPage,
 }) => {
-  await evilCas(credentialsPage.contents, credentialsPage.issuer);
-  await validSiteProfile({ privateKey, publicKey }, credentialsPage.issuer);
+  await evilCas(credentialsPage.contents, credentialsPage.holder);
+  await validSiteProfile(
+    { privateKey, publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
@@ -78,17 +83,21 @@ test("SPの署名がその発行者のOPで配布される検証鍵を使って�
   await validCas(
     { privateKey },
     credentialsPage.contents,
-    credentialsPage.issuer,
+    credentialsPage.holder,
   );
-  await evilSiteProfile({ publicKey }, credentialsPage.issuer);
+  await evilSiteProfile(
+    { publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();
 
   await gotoDetailPage(ext);
   await expectStatus(ext, "site-profile", "cancel");
-  await expectStatus(ext, "originator-profile-set-top", "check");
-  await expectStatus(ext, "content-attestation-set", "check");
+  await expectStatus(ext, "originator-profile-set-top", "null");
+  await expectStatus(ext, "content-attestation-set", "cancel");
   await expectStatus(ext, "core-profile", "cancel");
   await expectStatus(ext, "profile-annotation", "cancel");
   await expectStatus(ext, "web-media-profile", "cancel");
@@ -101,8 +110,12 @@ test("SPとCAの署名がその発行者のOPまたはSPで配布される検証
   evilCas: evilCas,
   credentialsPage,
 }) => {
-  await evilCas(credentialsPage.contents, credentialsPage.issuer);
-  await evilSiteProfile({ publicKey }, credentialsPage.issuer);
+  await evilCas(credentialsPage.contents, credentialsPage.holder);
+  await evilSiteProfile(
+    { publicKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext?.getByTestId("p-elm-prohibition-message")).toBeVisible();

--- a/apps/inspector/e2e/site-profile-with-credentials-fetch-failed.test.ts
+++ b/apps/inspector/e2e/site-profile-with-credentials-fetch-failed.test.ts
@@ -14,7 +14,11 @@ test("SiteProfileは検証成功するが、OPS / CASの取得に失敗した時
   missingCredentials: _missingCredentials,
   credentialsPage,
 }) => {
-  await validSiteProfile({ publicKey, privateKey }, credentialsPage.issuer);
+  await validSiteProfile(
+    { publicKey, privateKey },
+    credentialsPage.issuer,
+    credentialsPage.holder,
+  );
   await page.goto(credentialsPage.endpoint);
   const ext = await sidepanel(context);
   await expect(ext.getByTestId("site-profile")).toBeVisible();

--- a/apps/inspector/e2e/site-profile.test.ts
+++ b/apps/inspector/e2e/site-profile.test.ts
@@ -18,6 +18,7 @@ test("Site Profile を取得検証できる", async ({
   await validSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -47,6 +48,7 @@ test("Site Profile のビジュアルリグレッションテスト", async ({
   await validSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -63,6 +65,7 @@ test("Site Profile を取得検証できるが、WMP が存在しない", async 
   await missingMediaSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -84,6 +87,7 @@ test("Site Profile を取得検証できるが、有効期限が近く、詳細�
   await expiringSoonSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);
@@ -108,6 +112,7 @@ test("詳細情報画面に検証中の警告ログが表示される", async ({
   await validSiteProfile(
     { privateKey, publicKey },
     credentialsMissingPage.issuer,
+    credentialsMissingPage.holder,
   );
   await page.goto(credentialsMissingPage.endpoint);
   const ext = await sidepanel(context);

--- a/apps/inspector/e2e/static-html-fixtures.ts
+++ b/apps/inspector/e2e/static-html-fixtures.ts
@@ -5,9 +5,20 @@ type TestFixtures = {
     contents: string;
     endpoint: string;
     issuer: string;
+    holder: string;
   };
-  credentialsPage: { contents: string; endpoint: string; issuer: string };
-  onlineAdPage: { contents: string; endpoint: string; issuer: string };
+  credentialsPage: {
+    contents: string;
+    endpoint: string;
+    issuer: string;
+    holder: string;
+  };
+  onlineAdPage: {
+    contents: string;
+    endpoint: string;
+    issuer: string;
+    holder: string;
+  };
 };
 
 export const test = base.extend<TestFixtures>({
@@ -38,6 +49,7 @@ export const test = base.extend<TestFixtures>({
       contents: credentialsMissingHtml,
       endpoint,
       issuer: "dns:localhost",
+      holder: "dns:op-holder.example.com",
     });
 
     await page.unroute(endpoint);
@@ -75,6 +87,7 @@ export const test = base.extend<TestFixtures>({
       contents: validCredentialsHtml,
       endpoint,
       issuer: "dns:localhost",
+      holder: "dns:op-holder.example.com",
     });
 
     await page.unroute(endpoint);
@@ -114,7 +127,12 @@ export const test = base.extend<TestFixtures>({
       }),
     );
 
-    await use({ contents: onlineAdHtml, endpoint, issuer: "dns:localhost" });
+    await use({
+      contents: onlineAdHtml,
+      endpoint,
+      issuer: "dns:localhost",
+      holder: "dns:op-holder.example.com",
+    });
 
     await page.unroute(endpoint);
   },

--- a/apps/inspector/e2e/tab-badge.test.ts
+++ b/apps/inspector/e2e/tab-badge.test.ts
@@ -24,6 +24,7 @@ test("クレデンシャルが存在するページでバッジに正しい数�
     { publicKey, privateKey },
     credentialsPage.contents,
     credentialsPage.issuer,
+    credentialsPage.holder,
   );
 
   // service workerを先に起動させる（別のページにアクセスしてトリガー）


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

- CP/PA/WMP を生成するときに holder を指定できるように引数を追加しました。
- SP/OPS を生成するときに holder を指定できるように引数を追加しました。
- issuer と credentialSubject.id が異なる値になるように設定しました。
- validOps の unroute タイミングを変更しました。
- "SPの署名がその発行者のOPで配布される検証鍵を使って検証できない場合閲覧禁止" のテストを修正しました。

close #92 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

- 修正内容に問題ないことをご確認ください。
- `pnpm e2e` テストが問題なく通ることをご確認ください。