### PR TITLE
fix(wordpress): CAサーバーのホスト名初期値の更新

### DIFF
--- a/packages/wordpress/README.md
+++ b/packages/wordpress/README.md
@@ -89,7 +89,7 @@ dns:media.example.com
 例:
 
 ```
-dprexpt.originator-profile.org
+playground.originator-profile.org
 ```
 
 **[認証情報]: CAサーバーへのアクセスに必要な情報を指定**

--- a/packages/wordpress/includes/admin.php
+++ b/packages/wordpress/includes/admin.php
@@ -148,7 +148,7 @@ function profile_ca_server_hostname_field() {
 		<input
 			name="profile_ca_server_hostname"
 			value="<?php echo \esc_attr( \get_option( 'profile_ca_server_hostname' ) ); ?>"
-			title="有効なドメイン名を入力してください (例: dprexpt.originator-profile.org)"
+			title="有効なドメイン名を入力してください (例: playground.originator-profile.org)"
 			placeholder="<?php echo \esc_attr( PROFILE_DEFAULT_CA_SERVER_HOSTNAME ); ?>"
 			required
 			style="width: 320px;"

--- a/packages/wordpress/includes/config.php
+++ b/packages/wordpress/includes/config.php
@@ -4,7 +4,7 @@
 namespace Profile\Config;
 
 /** Content Attestation サーバーのホスト名の設定の初期値 */
-const PROFILE_DEFAULT_CA_SERVER_HOSTNAME = 'dprexpt.originator-profile.org';
+const PROFILE_DEFAULT_CA_SERVER_HOSTNAME = 'playground.originator-profile.org';
 
 /** Content Attestation サーバーのリクエストタイムアウト (秒) の初期値 */
 const PROFILE_DEFAULT_CA_SERVER_REQUEST_TIMEOUT = 30;


### PR DESCRIPTION
## Summary
- CA サーバーのホスト名初期値（デフォルトエンドポイント）を `dprexpt.originator-profile.org` から `playground.originator-profile.org` に変更
- README・管理画面のプレースホルダー例・設定定数の3箇所を統一して更新

## Test plan
- [x] WordPress 管理画面で CA サーバーのホスト名フィールドの初期値・プレースホルダー表示を確認