### PR TITLE
[ca-client] readCasFileを公開する

### DIFF
--- a/packages/ca-client/README.md
+++ b/packages/ca-client/README.md
@@ -133,20 +133,10 @@ const jwt = await client.sign({
 第 2 引数は payload が不正なとき、エラーメッセージに埋め込む識別子です。
 
 ```ts
-import { readFile } from "node:fs/promises";
+import { readCasFile } from "@originator-profile/ca-client";
 
-const casJson = JSON.parse(
-  await readFile("dist/cas/ja-JP.page.cas.json", "utf8"),
-);
-const jwt = casJson[0]; // CAS ファイルは JWT の配列
-const existingPayload = JSON.parse(
-  Buffer.from(jwt.split(".")[1], "base64url").toString("utf8"),
-);
-
-const renewed = await client.reSign(
-  existingPayload,
-  "dist/cas/ja-JP.page.cas.json",
-);
+const { payload } = await readCasFile("dist/cas/ja-JP.page.cas.json");
+const renewed = await client.reSign(payload, "dist/cas/ja-JP.page.cas.json");
 ```
 
 `createCaClient` に渡した `issuer` が、payload の `issuer` より優先されます。
@@ -168,6 +158,18 @@ await writeCasFile({
 
 ```json
 ["eyJ..."]
+```
+
+### readCasFile
+
+`readCasFile` は、[CAS](https://docs.originator-profile.org/ja/opb/content-attestation-set/) ファイルを読み、先頭 JWT とデコード済み payload を返します。相対パスは cwd 基準です。
+
+payload は署名検証をしない VC 文書です。JWT の `iss` / `iat` / `exp` は含まれません。`reSign` にそのまま渡せます。複数要素の CAS は先頭 1 件のみ読みます。
+
+```ts
+import { readCasFile } from "@originator-profile/ca-client";
+
+const { jwt, payload } = await readCasFile("dist/cas/ja-JP.page.cas.json");
 ```
 
 ### detectDrift

--- a/packages/ca-client/package.json
+++ b/packages/ca-client/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@originator-profile/model": "workspace:*",
+    "@originator-profile/securing-mechanism": "workspace:*",
     "@originator-profile/sign": "workspace:*",
     "jsdom": "^29.0.1"
   },

--- a/packages/ca-client/src/cas-store/file.test.ts
+++ b/packages/ca-client/src/cas-store/file.test.ts
@@ -3,7 +3,13 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "vitest";
 import { CaClientError, CaClientErrorCode } from "../errors";
-import { deleteCasFiles, resolveCasFilePath, writeCasFile } from "./file";
+import {
+  deleteCasFiles,
+  parseCasFileContent,
+  readCasFile,
+  resolveCasFilePath,
+  writeCasFile,
+} from "./file";
 
 const withTempDir = async (run: (dir: string) => Promise<void>) => {
   const dir = await mkdtemp(join(tmpdir(), "ca-client-cas-store-"));
@@ -211,4 +217,105 @@ test("resolveCasFilePath: rejects an empty path so it is not resolved to cwd", (
       "filePath must be a non-empty string",
     );
   }
+});
+
+const INVALID_CAS_FORMAT =
+  "Invalid CAS file format (expected JSON array with JWT string)";
+
+const encodeJwt = (
+  payload: unknown,
+  header: Record<string, unknown> = { alg: "ES256", typ: "vc+jwt" },
+) =>
+  `${Buffer.from(JSON.stringify(header)).toString("base64url")}.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.sig`;
+
+test("parseCasFileContent: returns the leading JWT", () => {
+  const token = "header.payload.signature";
+  expect(parseCasFileContent(JSON.stringify([token]))).toBe(token);
+});
+
+test("parseCasFileContent: accepts { main, attestation } items", () => {
+  const token = "header.payload.signature";
+  expect(
+    parseCasFileContent(JSON.stringify([{ main: true, attestation: token }])),
+  ).toBe(token);
+});
+
+test("parseCasFileContent: rejects a non-array document", () => {
+  expect(() => parseCasFileContent(JSON.stringify({ notArray: true }))).toThrow(
+    CaClientError,
+  );
+  expect(() => parseCasFileContent(JSON.stringify({ notArray: true }))).toThrow(
+    INVALID_CAS_FORMAT,
+  );
+});
+
+test("parseCasFileContent: surfaces JSON.parse errors as CA_VALIDATION", () => {
+  expect(() => parseCasFileContent("{invalid")).toThrow(CaClientError);
+  expect(() => parseCasFileContent("{invalid")).toThrow(/JSON/i);
+});
+
+test("readCasFile: returns jwt and payload with JWT registered claims stripped", async () => {
+  await withTempDir(async (dir) => {
+    const payload = {
+      target: [{ type: "TextTargetIntegrity" }],
+      iss: "dns:x",
+      credentialSubject: { id: "urn:uuid:1" },
+    };
+    const jwt = encodeJwt(payload);
+    const filePath = join(dir, "ja-JP.about.cas.json");
+    await writeFile(filePath, JSON.stringify([jwt]));
+
+    const result = await readCasFile(filePath);
+    expect(result.jwt).toBe(jwt);
+    expect(result.payload).toEqual({
+      target: payload.target,
+      credentialSubject: payload.credentialSubject,
+    });
+  });
+});
+
+test("readCasFile: reads a file written by writeCasFile", async () => {
+  await withTempDir(async (dir) => {
+    const payload = { credentialSubject: { id: "urn:uuid:roundtrip" } };
+    const jwt = encodeJwt(payload);
+    const filePath = join(dir, "cas", "page.cas.json");
+
+    await writeCasFile({ filePath, jwt });
+    const result = await readCasFile(filePath);
+
+    expect(result.jwt).toBe(jwt);
+    expect(result.payload).toEqual(payload);
+  });
+});
+
+test("readCasFile: wraps missing files as CA_FILE", async () => {
+  const missing = join(tmpdir(), "missing-cas-file.cas.json");
+  await expect(readCasFile(missing)).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.File,
+    message: expect.stringMatching(
+      `^Failed to read CAS file ${resolve(missing)}:`,
+    ),
+  });
+});
+
+test("readCasFile: rejects an empty filePath as CA_VALIDATION", async () => {
+  await expect(readCasFile("   ")).rejects.toMatchObject({
+    name: "CaClientError",
+    code: CaClientErrorCode.Validation,
+    message: "filePath must be a non-empty string",
+  });
+});
+
+test("readCasFile: rejects an invalid JWT as CA_VALIDATION", async () => {
+  await withTempDir(async (dir) => {
+    const filePath = join(dir, "bad.cas.json");
+    await writeFile(filePath, JSON.stringify(["not-a-jwt"]));
+
+    await expect(readCasFile(filePath)).rejects.toMatchObject({
+      name: "CaClientError",
+      code: CaClientErrorCode.Validation,
+      message: "Failed to decode CAS JWT: JWT VC Decoding Failure",
+    });
+  });
 });

--- a/packages/ca-client/src/cas-store/file.ts
+++ b/packages/ca-client/src/cas-store/file.ts
@@ -1,7 +1,13 @@
-import { mkdir, unlink, writeFile } from "node:fs/promises";
+import { ContentAttestationSet } from "@originator-profile/model";
+import {
+  JwtVcDecoder,
+  VcDecodeFailed,
+} from "@originator-profile/securing-mechanism";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { CaClientError, CaClientErrorCode } from "../errors";
 import { isEnoent, toFileError } from "../file-utils";
+import { isRecord } from "../is-record";
 
 export type WriteCasFileOptions = {
   /**
@@ -34,6 +40,89 @@ export const resolveCasFilePath = (filePath: string): string => {
     });
   }
   return resolve(filePath);
+};
+
+const INVALID_CAS_FORMAT =
+  "Invalid CAS file format (expected JSON array with JWT string)";
+
+const jwtVcDecoder = JwtVcDecoder();
+
+const jwtFromCasItem = (item: unknown): string | undefined => {
+  if (typeof item === "string") {
+    return item;
+  }
+  if (!isRecord(item) || typeof item.attestation !== "string") {
+    return undefined;
+  }
+  return item.attestation;
+};
+
+/**
+ * Take the leading JWT from CAS file JSON (`["<JWT>"]` or
+ * `[{ main: true, attestation: "<JWT>" }]`).
+ */
+export const parseCasFileContent = (fileContent: string): string => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fileContent);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new CaClientError(detail, {
+      code: CaClientErrorCode.Validation,
+      cause: error,
+    });
+  }
+
+  const cas = ContentAttestationSet.safeParse(parsed);
+  if (!cas.success) {
+    throw new CaClientError(INVALID_CAS_FORMAT, {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+
+  const jwt = jwtFromCasItem(cas.data[0]);
+  if (!jwt) {
+    throw new CaClientError(INVALID_CAS_FORMAT, {
+      code: CaClientErrorCode.Validation,
+    });
+  }
+
+  return jwt;
+};
+
+const decodeCasJwt = (token: string): Record<string, unknown> => {
+  const decoded = jwtVcDecoder(token);
+  if (decoded instanceof VcDecodeFailed) {
+    throw new CaClientError(`Failed to decode CAS JWT: ${decoded.message}`, {
+      code: CaClientErrorCode.Validation,
+      cause: decoded,
+    });
+  }
+  return decoded.doc;
+};
+
+export type ReadCasFileResult = {
+  jwt: string;
+  payload: Record<string, unknown>;
+};
+
+/**
+ * Read a CAS file and return its JWT and decoded payload.
+ * Read counterpart of `writeCasFile`. Relative paths resolve against cwd.
+ */
+export const readCasFile = async (
+  filePath: string,
+): Promise<ReadCasFileResult> => {
+  const dest = resolveCasFilePath(filePath);
+  let fileContent: string;
+  try {
+    fileContent = await readFile(dest, "utf8");
+  } catch (error) {
+    throw toFileError(`Failed to read CAS file ${dest}`, error);
+  }
+
+  const jwt = parseCasFileContent(fileContent);
+  return { jwt, payload: decodeCasJwt(jwt) };
 };
 
 export const writeCasFile = async ({

--- a/packages/ca-client/src/drift/compare.ts
+++ b/packages/ca-client/src/drift/compare.ts
@@ -1,7 +1,6 @@
-import { ContentAttestationSet } from "@originator-profile/model";
 import { readFile } from "node:fs/promises";
 import { decodeJwtPayload } from "../auth/jwt";
-import { resolveCasFilePath } from "../cas-store/file";
+import { parseCasFileContent, resolveCasFilePath } from "../cas-store/file";
 import { isEnoent, toFileError } from "../file-utils";
 import { isRecord } from "../is-record";
 import {
@@ -53,19 +52,6 @@ type CasTarget = {
   type: string;
   cssSelector?: string;
   integrity: string;
-};
-
-const INVALID_CAS_FORMAT =
-  "Invalid CAS file format (expected JSON array with JWT string)";
-
-const jwtFromCasItem = (item: unknown): string | undefined => {
-  if (typeof item === "string") {
-    return item;
-  }
-  if (isRecord(item) && typeof item.attestation === "string") {
-    return item.attestation;
-  }
-  return undefined;
 };
 
 const isCasTarget = (value: unknown): value is CasTarget =>
@@ -126,22 +112,12 @@ type ReadCasTargetsResult =
   | { ok: false; reason: string };
 
 const parseCasTargets = (casFileContent: string): ReadCasTargetsResult => {
-  let parsed: unknown;
+  let jwt: string;
   try {
-    parsed = JSON.parse(casFileContent);
+    jwt = parseCasFileContent(casFileContent);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     return { ok: false, reason: detail };
-  }
-
-  const cas = ContentAttestationSet.safeParse(parsed);
-  if (!cas.success) {
-    return { ok: false, reason: INVALID_CAS_FORMAT };
-  }
-
-  const jwt = jwtFromCasItem(cas.data[0]);
-  if (!jwt) {
-    return { ok: false, reason: INVALID_CAS_FORMAT };
   }
 
   try {

--- a/packages/ca-client/src/index.test.ts
+++ b/packages/ca-client/src/index.test.ts
@@ -1,9 +1,10 @@
 import { expect, test } from "vitest";
 import * as publicApi from "./index";
 
-test("public API: exports createCaClient, writeCasFile, detectDrift, and error types", () => {
+test("public API: exports createCaClient, writeCasFile, readCasFile, detectDrift, and error types", () => {
   expect(typeof publicApi.createCaClient).toBe("function");
   expect(typeof publicApi.writeCasFile).toBe("function");
+  expect(typeof publicApi.readCasFile).toBe("function");
   expect(typeof publicApi.detectDrift).toBe("function");
   expect(typeof publicApi.isUnauthorized).toBe("function");
   expect(publicApi.CaClientError).toBeDefined();
@@ -13,6 +14,7 @@ test("public API: exports createCaClient, writeCasFile, detectDrift, and error t
     "createCaClient",
     "detectDrift",
     "isUnauthorized",
+    "readCasFile",
     "writeCasFile",
   ]);
 });
@@ -26,6 +28,7 @@ test("public API: does not export low-level APIs from index", () => {
   expect(api.signByCaServer).toBeUndefined();
   expect(api.deleteCasFiles).toBeUndefined();
   expect(api.resolveCasFilePath).toBeUndefined();
+  expect(api.parseCasFileContent).toBeUndefined();
   expect(api.extractTargetsFromHtml).toBeUndefined();
   expect(api.extractTextTargetIntegrity).toBeUndefined();
   expect(api.htmlMatchesCasTargets).toBeUndefined();

--- a/packages/ca-client/src/index.ts
+++ b/packages/ca-client/src/index.ts
@@ -3,7 +3,12 @@ export {
   type CaClient,
   type CaClientConfig,
 } from "./ca-client/create-ca-client";
-export { writeCasFile, type WriteCasFileOptions } from "./cas-store/file";
+export {
+  readCasFile,
+  writeCasFile,
+  type ReadCasFileResult,
+  type WriteCasFileOptions,
+} from "./cas-store/file";
 export {
   detectDrift,
   type DetectDriftOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@originator-profile/model':
         specifier: workspace:*
         version: link:../model
+      '@originator-profile/securing-mechanism':
+        specifier: workspace:*
+        version: link:../securing-mechanism
       '@originator-profile/sign':
         specifier: workspace:*
         version: link:../sign


### PR DESCRIPTION
## 変更内容

(何を・なぜ変更したか)

`ca-client` にCASファイルを読み込む `readCasFile` を追加し、公開します。

close #510 

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)

readCasFileがexportされていることが確認できればOKです。README.mdの文言などをみて使用方法がわかりにくくないかなど確認お願いします。
