### PR TITLE
[opvc, ca-client] documentProviderをsignから呼び出すように変更

### DIFF
--- a/packages/ca-client/src/ca-client/document-provider.ts
+++ b/packages/ca-client/src/ca-client/document-provider.ts
@@ -1,65 +1,72 @@
 import type { RawTarget } from "@originator-profile/model";
+import { createDocumentProvider, FetchFailed } from "@originator-profile/sign";
 import { JSDOM } from "jsdom";
 import { CaClientError, CaClientErrorCode } from "../errors";
 import type { FetchOperations } from "../fetch-operations";
 
-async function fetchDocument(
-  url: string,
+function parseDocument(html: string, url?: string): Document {
+  return new JSDOM(html, { url }).window.document;
+}
+
+function fetchDocument(
   fetchOps: FetchOperations,
-): Promise<string> {
-  let res: Response;
-  try {
-    res = await fetchOps.fetch(url);
-  } catch (error) {
-    throw new CaClientError(
-      `Failed to fetch document: ${error instanceof Error ? error.message : String(error)}`,
-      { code: CaClientErrorCode.Http, cause: error },
+): (url: string) => Promise<Response> {
+  return async (url) => {
+    let res: Response;
+    try {
+      res = await fetchOps.fetch(url);
+    } catch (error) {
+      throw new CaClientError(
+        `Failed to fetch document: ${error instanceof Error ? error.message : String(error)}`,
+        { code: CaClientErrorCode.Http, cause: error },
+      );
+    }
+
+    if (!res.ok) {
+      throw new CaClientError(
+        `Failed to fetch document: ${res.status} ${res.statusText}`,
+        { code: CaClientErrorCode.Http, status: res.status },
+      );
+    }
+
+    return res;
+  };
+}
+
+function toCaClientError(error: unknown): CaClientError {
+  if (error instanceof CaClientError) {
+    return error;
+  }
+
+  if (error instanceof FetchFailed) {
+    if (error.error instanceof CaClientError) {
+      return error.error;
+    }
+
+    return new CaClientError(
+      `Failed to fetch document: ${error.error.message}`,
+      { code: CaClientErrorCode.Http, cause: error.error },
     );
   }
 
-  if (!res.ok) {
-    throw new CaClientError(
-      `Failed to fetch document: ${res.status} ${res.statusText}`,
-      { code: CaClientErrorCode.Http, status: res.status },
-    );
-  }
-
-  return await res.text();
+  return new CaClientError(
+    `Invalid Content Attestation: ${error instanceof Error ? error.message : String(error)}`,
+    { code: CaClientErrorCode.Validation, cause: error },
+  );
 }
 
 export async function documentProvider(
-  { type, content = "" }: RawTarget,
+  raw: RawTarget,
   fetchOps: FetchOperations = { fetch },
 ): Promise<Document> {
-  if (type === "ExternalResourceTargetIntegrity") {
-    throw new CaClientError(
-      "Invalid Content Attestation: ExternalResourceTargetIntegrity is not supported",
-      { code: CaClientErrorCode.Validation },
-    );
-  }
-
-  if (Array.isArray(content) && content.length > 1) {
-    throw new CaClientError(
-      "Invalid Content Attestation: multiple contents are not supported",
-      { code: CaClientErrorCode.Validation },
-    );
-  }
-
-  const flatContent = Array.isArray(content) ? (content[0] ?? "") : content;
-  let url: string | undefined;
-  let html: string;
-
-  if (URL.canParse(flatContent)) {
-    url = flatContent;
-    html = await fetchDocument(url, fetchOps);
-  } else {
-    url = undefined;
-    html = flatContent;
-  }
-
-  const dom = new JSDOM(html, {
-    url,
+  const provide = createDocumentProvider({
+    fetch: fetchDocument(fetchOps),
+    parseDocument,
   });
 
-  return dom.window.document;
+  try {
+    return await provide(raw);
+  } catch (error) {
+    throw toCaClientError(error);
+  }
 }

--- a/packages/opvc/src/document-provider.ts
+++ b/packages/opvc/src/document-provider.ts
@@ -1,35 +1,7 @@
-import type { RawTarget } from "@originator-profile/model";
+import { createDocumentProvider } from "@originator-profile/sign";
 import { JSDOM } from "jsdom";
 
-export async function documentProvider({
-  type,
-  content = "",
-}: RawTarget): Promise<Document> {
-  if (type === "ExternalResourceTargetIntegrity") {
-    throw new Error(
-      "ExternalResourceTargetIntegrity is not supported in this context.",
-    );
-  }
-
-  if (Array.isArray(content) && content.length > 1) {
-    throw new Error("Multiple contents are not supported in this context.");
-  }
-
-  [content] = [content].flat();
-  let url: string | undefined;
-  let html: string;
-
-  if (URL.canParse(content)) {
-    url = content;
-    html = await fetch(url).then((res) => res.text());
-  } else {
-    url = undefined;
-    html = content;
-  }
-
-  const dom = new JSDOM(html, {
-    url,
-  });
-
-  return dom.window.document;
-}
+export const documentProvider = createDocumentProvider({
+  parseDocument: (html: string, url?: string) =>
+    new JSDOM(html, { url }).window.document,
+});

--- a/packages/sign/src/integrity/document-provider.test.ts
+++ b/packages/sign/src/integrity/document-provider.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDocumentProvider } from "./document-provider";
+import { FetchFailed, UnsupportedDocumentTarget } from "./error";
+
+function parseDocument(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}
+
+describe("createDocumentProvider()", () => {
+  it("parses inline HTML", async () => {
+    const documentProvider = createDocumentProvider({ parseDocument });
+
+    const document = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: "<body><main>hello</main></body>",
+    });
+
+    expect(document.querySelector("main")?.textContent).toBe("hello");
+  });
+
+  it("fetches HTML when content is a URL", async () => {
+    const fetcher = vi.fn(
+      async () =>
+        new Response("<body><main>from-url</main></body>", { status: 200 }),
+    );
+    const parsed = vi.fn(parseDocument);
+    const documentProvider = createDocumentProvider({
+      fetch: fetcher,
+      parseDocument: parsed,
+    });
+
+    const document = await documentProvider({
+      type: "HtmlTargetIntegrity",
+      content: "https://example.com/article",
+    });
+
+    expect(document.querySelector("main")?.textContent).toBe("from-url");
+    expect(fetcher).toHaveBeenCalledWith("https://example.com/article");
+    expect(parsed).toHaveBeenCalledWith(
+      "<body><main>from-url</main></body>",
+      "https://example.com/article",
+    );
+  });
+
+  it("does not treat non-OK HTTP responses as failures", async () => {
+    const documentProvider = createDocumentProvider({
+      fetch: async () =>
+        new Response("<body><main>not found</main></body>", { status: 404 }),
+      parseDocument,
+    });
+
+    const document = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: "https://example.com/article",
+    });
+
+    expect(document.querySelector("main")?.textContent).toBe("not found");
+  });
+
+  it("wraps fetch failures as FetchFailed", async () => {
+    const cause = new TypeError("Failed to fetch");
+    const documentProvider = createDocumentProvider({
+      fetch: async () => {
+        throw cause;
+      },
+      parseDocument,
+    });
+
+    const error = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: "https://example.com/article",
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(FetchFailed);
+    expect(error).toMatchObject({
+      message: "Failed to fetch",
+      error: cause,
+    });
+  });
+
+  it("treats empty or omitted content as empty HTML", async () => {
+    const documentProvider = createDocumentProvider({ parseDocument });
+
+    const fromEmptyArray = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: [],
+    });
+    const fromEmptyString = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: "",
+    });
+    const fromOmitted = await documentProvider({
+      type: "TextTargetIntegrity",
+    });
+
+    expect(fromEmptyArray.body?.textContent).toBe("");
+    expect(fromEmptyString.body?.textContent).toBe("");
+    expect(fromOmitted.body?.textContent).toBe("");
+  });
+
+  it("parses a single-element content array", async () => {
+    const documentProvider = createDocumentProvider({ parseDocument });
+
+    const document = await documentProvider({
+      type: "TextTargetIntegrity",
+      content: ["<body><main>hello</main></body>"],
+    });
+
+    expect(document.querySelector("main")?.textContent).toBe("hello");
+  });
+
+  it("rejects unsupported target types and multiple contents", async () => {
+    const documentProvider = createDocumentProvider({ parseDocument });
+
+    await expect(
+      documentProvider({
+        type: "ExternalResourceTargetIntegrity",
+        content: "https://example.com/image.png",
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedDocumentTarget);
+
+    await expect(
+      documentProvider({
+        type: "TextTargetIntegrity",
+        content: ["<p>a</p>", "<p>b</p>"],
+      }),
+    ).rejects.toBeInstanceOf(UnsupportedDocumentTarget);
+  });
+});

--- a/packages/sign/src/integrity/document-provider.ts
+++ b/packages/sign/src/integrity/document-provider.ts
@@ -1,0 +1,69 @@
+import type { RawTarget } from "@originator-profile/model";
+import { FetchFailed, UnsupportedDocumentTarget } from "./error";
+import type { DocumentProvider } from "./types";
+
+export type CreateDocumentProviderOptions = {
+  fetch?: (url: string) => Promise<Response>;
+  parseDocument: (html: string, url?: string) => Document;
+};
+
+function isError(value: unknown): value is Error {
+  return (
+    value instanceof Error ||
+    (typeof window !== "undefined" && value instanceof window.Error)
+  );
+}
+
+async function fetchHtml(
+  url: string,
+  fetcher: (url: string) => Promise<Response>,
+): Promise<string> {
+  let res: Response;
+  try {
+    res = await fetcher(url);
+  } catch (e) {
+    if (e instanceof FetchFailed) {
+      throw e;
+    }
+    if (isError(e)) {
+      throw new FetchFailed(`Failed to fetch`, e);
+    }
+    throw e;
+  }
+
+  return await res.text();
+}
+
+/** HTTP ステータスは見ない。非 2xx を失敗にするなら `fetch` 側で throw する。 */
+export function createDocumentProvider({
+  fetch: fetcher = fetch,
+  parseDocument,
+}: CreateDocumentProviderOptions): DocumentProvider {
+  return async ({ type, content = "" }: RawTarget): Promise<Document> => {
+    if (type === "ExternalResourceTargetIntegrity") {
+      throw new UnsupportedDocumentTarget(
+        "ExternalResourceTargetIntegrity is not supported in this context.",
+      );
+    }
+
+    if (Array.isArray(content) && content.length > 1) {
+      throw new UnsupportedDocumentTarget(
+        "Multiple contents are not supported in this context.",
+      );
+    }
+
+    const flatContent = Array.isArray(content) ? (content[0] ?? "") : content;
+    let url: string | undefined;
+    let html: string;
+
+    if (URL.canParse(flatContent)) {
+      url = flatContent;
+      html = await fetchHtml(url, fetcher);
+    } else {
+      url = undefined;
+      html = flatContent;
+    }
+
+    return parseDocument(html, url);
+  };
+}

--- a/packages/sign/src/integrity/error.ts
+++ b/packages/sign/src/integrity/error.ts
@@ -12,3 +12,11 @@ export class FetchFailed extends Error {
     this.error = error;
   }
 }
+
+/** DocumentProvider が扱えない Target */
+export class UnsupportedDocumentTarget extends Error {
+  static get code() {
+    return "ERR_UNSUPPORTED_DOCUMENT_TARGET" as const;
+  }
+  readonly code = UnsupportedDocumentTarget.code;
+}

--- a/packages/sign/src/integrity/index.ts
+++ b/packages/sign/src/integrity/index.ts
@@ -1,4 +1,5 @@
 export * from "./digest-sri";
+export * from "./document-provider";
 export * from "./error";
 export * from "./fetch-and-set-digest-sri";
 export * from "./fetch-and-set-target-integrity";


### PR DESCRIPTION
## 変更内容

`opvc` と `ca-client` で重複していた `documentProvider`（URL / HTML の分岐、未対応 target の拒否、単一 content の正規化）を、`@originator-profile/sign` の `createDocumentProvider` に切り出しました。

- `sign`: `fetch` と `parseDocument` を注入するファクトリ。HTTP ステータスは見ない
- `opvc`: JSDOM の `parseDocument` だけ渡す
- `ca-client`: 既存どおり `fetchOps` を注入し、非 2xx / ネットワーク失敗を `CaClientError`（`CA_HTTP`）、それ以外を `CA_VALIDATION` に載せ替える

`opvc` に実装して `ca-client` から呼ぶ案は採用しませんでした。
`opvc` は oclif の CLI で、`ca-client` はライブラリです。
ライブラリが CLI に依存すると層が逆になり、oclif や `jsdom` まで依存してしまいます。
`DocumentProvider` 型とそれを渡す `fetchAndSetTargetIntegrity` / `signCa` はすでに `sign` にあったため、`sign` から呼ぶ形としました。

`sign` に置いたのは、`opvc` と `ca-client` がどちらも依存している下位パッケージだからです。
完成した JSDOM 実装ではなくファクトリにしたのは、`sign` のデフォルトがブラウザの `document` であり、`jsdom` を足すと `verify` などブラウザ向け利用まで Node 依存になるためです。
`createDigestSri` と同様に `fetch` は注入点として残し、非 2xx や `CaClientError` は呼び出し側の責務のままにしました。

close #464

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

### ca-client に影響がないこと

公開 API（`createCaClient` / `signByCaServer`）のシグネチャは変えていません。`documentProvider` は引き続き `fetchOps` を受け取り、非 2xx とネットワーク失敗を `CA_HTTP`、未対応 type / 複数 content を `CA_VALIDATION` にします。既存テストが次を固定しています。

- インライン HTML と URL 取得
- `fetchOps.fetch` が呼ばれること
- `Failed to fetch document: Failed to fetch`（cause 付き）
- `Failed to fetch document: 404 Not Found`（`status: 404`）
- 空 / 省略 content は空 HTML
- `ExternalResourceTargetIntegrity` と複数 content は `CA_VALIDATION`

### opvc に影響がないこと

成功経路は以前と同じです。JSDOM の `{ url }`、URL / `data:` の `fetch`、非整形式 HTML のパース、非 2xx を HTML として扱う点は変えていません。既存の `documentProvider` テスト（開き/閉じタグ省略、`data:` URL、`ExternalResourceTargetIntegrity` 拒否）がこれを固定しています。

`unsignedCa` / `sign` は従来どおりこの `documentProvider` を渡します。バリデーション文言は同じで、`unsignedCa` は `BadRequestError((e as Error).message)` のため CLI のメッセージも同じです。`content: []` は以前 `undefined`、今は `""` を JSDOM に渡しますが、どちらも空の `<html><head></head><body></body></html>` になり差はありません。
