### PR TITLE
fix(wordpress): WordPressプラグイン API認証(OIDC)画面404エラー対応

### DIFF
--- a/packages/wordpress/includes/admin.php
+++ b/packages/wordpress/includes/admin.php
@@ -306,7 +306,7 @@ function profile_ca_log_option_field() {
  */
 function add_action_links( array $actions ) {
 	$menu_settings_url = '<a href="' . \get_admin_url( null, '/options-general.php?page=ca-manager' ) . '">設定</a>';
-	$menu_auth_url     = '<a href="' . \get_home_url( null, '/oidc-callback/' ) . '" target="_blank">API認証(OIDC)</a>';
+	$menu_auth_url = '<a href="' . \esc_url( \add_query_arg( \Profile\CasApiOidcCallback\OIDC_CALLBACK_ENDPOINT, '1', \home_url( '/' ) ) ) . '" target="_blank">API認証(OIDC)</a>';
 
 	array_unshift( $actions, $menu_auth_url );
 	array_unshift( $actions, $menu_settings_url );


### PR DESCRIPTION
## 変更内容

WordPress 7.x にてAPI認証(OIDC)画面が404エラーとなったため、これを修正した。
バージョンアップによるクエリ厳格化の影響と思われる。
パーマリンク設定が「基本」以外では発生しない。

あくまでこの修正は、API認証(OIDC)画面を表示するまでの修正のみ。
合わせて、OIDCリダイレクトURL自体の変更(クエリ形式)が必要となる。
CAサーバの次期リリースにて対応予定。
APIアカウント設定でリダイレクトURLを修正し、WordPress認証情報更新が必要。

それまでのワークアラウンドとして、パーマリンク設定の変更が可能であれば「基本」以外にする事で対応可能。

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

修正前バージョン：
パーマリンク設定：「基本」で、CA-Manager API認証(OIDC) クリックで 404エラー

修正後バージョン：
パーマリンク設定：「基本」で、CA-Manager API認証(OIDC) クリックで 認証画面表示