### PR TITLE
fix(wordpress): admin.php の代入演算子の位置揃えを修正

### DIFF
--- a/packages/wordpress/includes/admin.php
+++ b/packages/wordpress/includes/admin.php
@@ -306,7 +306,7 @@ function profile_ca_log_option_field() {
  */
 function add_action_links( array $actions ) {
 	$menu_settings_url = '<a href="' . \get_admin_url( null, '/options-general.php?page=ca-manager' ) . '">設定</a>';
-	$menu_auth_url = '<a href="' . \esc_url( \add_query_arg( \Profile\CasApiOidcCallback\OIDC_CALLBACK_ENDPOINT, '1', \home_url( '/' ) ) ) . '" target="_blank">API認証(OIDC)</a>';
+	$menu_auth_url     = '<a href="' . \esc_url( \add_query_arg( \Profile\CasApiOidcCallback\OIDC_CALLBACK_ENDPOINT, '1', \home_url( '/' ) ) ) . '" target="_blank">API認証(OIDC)</a>';
 
 	array_unshift( $actions, $menu_auth_url );
 	array_unshift( $actions, $menu_settings_url );


### PR DESCRIPTION
## Summary
- #518 マージ後に CI の Lint for WordPress Plugin が phpcs の `Equals sign not aligned with surrounding assignments` 警告で失敗していたのを修正
- `$menu_auth_url` の代入演算子を `$menu_settings_url` と揃えた（1 space → 5 spaces）

参照: https://github.com/originator-profile/originator-profile/actions/runs/34206421162/job/101996852888

## Test plan
- [x] CI の Lint for WordPress Plugin ジョブが通ることを確認