### PR TITLE
refactor(extension-common): タブのバッジ更新の配線を tab-badge へ移す

### DIFF
--- a/packages/extension-common/src/background.ts
+++ b/packages/extension-common/src/background.ts
@@ -3,11 +3,8 @@ import { frameCasExtensionMessenger } from "./frame-cas/extension-events";
 import { setupLinkVerification } from "./link-verification/background";
 import type { WarningUrlBuilder } from "./link-verification/types";
 import { overlayExtensionMessenger } from "./overlay/extension-events";
-import { updateBadge } from "./tab-badge/update-badge";
+import { setupTabBadge } from "./tab-badge/background";
 import "./utils/cors-basic-auth";
-
-/** バッジ更新のデバウンス時間（ミリ秒） */
-const BADGE_UPDATE_DEBOUNCE_MS = 300;
 
 /** Firefox のサイドバーの開閉を検知するポーリング間隔（ミリ秒） */
 const SIDEBAR_POLL_INTERVAL_MS = 500;
@@ -60,6 +57,7 @@ export type BackgroundConfig = {
  */
 export function setupBackground(config: BackgroundConfig) {
   setupLinkVerification(config.buildWarningUrl);
+  const { requestTabBadgeUpdate } = setupTabBadge(config.countCredentials);
 
   // Chromium: アクションクリック時にサイドパネルを開く
   if (chrome.sidePanel) {
@@ -116,50 +114,6 @@ export function setupBackground(config: BackgroundConfig) {
     });
   }
 
-  async function updateTabBadge(tabId: number): Promise<void> {
-    try {
-      await updateBadge(tabId, await config.countCredentials(tabId));
-    } catch (error) {
-      console.error(
-        `[updateTabBadge] Failed to update badge for tab ${tabId}:`,
-        error,
-      );
-    }
-  }
-
-  // デバウンス用のタイマーID（タブIDごとに管理）
-  const pendingBadgeUpdateTimers = new Map<
-    number,
-    ReturnType<typeof setTimeout>
-  >();
-
-  /** タブのバッジ更新をデバウンス付きで要求する */
-  function requestTabBadgeUpdate(tabId: number): void {
-    const existingTimer = pendingBadgeUpdateTimers.get(tabId);
-    if (existingTimer !== undefined) {
-      clearTimeout(existingTimer);
-    }
-
-    const timer = setTimeout(() => {
-      pendingBadgeUpdateTimers.delete(tabId);
-      void updateTabBadge(tabId);
-    }, BADGE_UPDATE_DEBOUNCE_MS);
-
-    pendingBadgeUpdateTimers.set(tabId, timer);
-  }
-
-  // タブ切り替え時にバッジを更新
-  chrome.tabs.onActivated.addListener(({ tabId }) => {
-    requestTabBadgeUpdate(tabId);
-  });
-
-  // ページ遷移完了時にバッジを更新（アクティブタブのみ）
-  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (changeInfo.status === "complete" && tab.active) {
-      requestTabBadgeUpdate(tabId);
-    }
-  });
-
   chrome.runtime.onInstalled.addListener(async ({ reason }) => {
     if (reason !== "install") return;
 
@@ -180,15 +134,6 @@ export function setupBackground(config: BackgroundConfig) {
     if (!granted) {
       // 権限が足らない場合は初期設定の説明を開く (Firefoxのみ)
       await chrome.tabs.create({ url: config.permissionGuideUrl });
-    }
-  });
-
-  // タブ削除時にデバウンスタイマーをクリーンアップ
-  chrome.tabs.onRemoved.addListener((tabId) => {
-    const timer = pendingBadgeUpdateTimers.get(tabId);
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      pendingBadgeUpdateTimers.delete(tabId);
     }
   });
 

--- a/packages/extension-common/src/tab-badge/background.ts
+++ b/packages/extension-common/src/tab-badge/background.ts
@@ -1,0 +1,70 @@
+import { updateBadge } from "./update-badge";
+
+/** バッジ更新のデバウンス時間（ミリ秒） */
+const BADGE_UPDATE_DEBOUNCE_MS = 300;
+
+/**
+ * タブのバッジ更新の Service Worker 側イベント配線を登録する
+ * @param countCredentials タブのバッジに表示するクレデンシャルの件数を数える
+ * @returns バッジ更新をデバウンス付きで要求する関数
+ */
+export function setupTabBadge(
+  countCredentials: (tabId: number) => Promise<number>,
+) {
+  async function updateTabBadge(tabId: number): Promise<void> {
+    try {
+      await updateBadge(tabId, await countCredentials(tabId));
+    } catch (error) {
+      console.error(
+        `[updateTabBadge] Failed to update badge for tab ${tabId}:`,
+        error,
+      );
+    }
+  }
+
+  // デバウンス用のタイマーID（タブIDごとに管理）
+  const pendingBadgeUpdateTimers = new Map<
+    number,
+    ReturnType<typeof setTimeout>
+  >();
+
+  /** タブのバッジ更新をデバウンス付きで要求する */
+  function requestTabBadgeUpdate(tabId: number): void {
+    const existingTimer = pendingBadgeUpdateTimers.get(tabId);
+    if (existingTimer !== undefined) {
+      clearTimeout(existingTimer);
+    }
+
+    const timer = setTimeout(() => {
+      pendingBadgeUpdateTimers.delete(tabId);
+      void updateTabBadge(tabId);
+    }, BADGE_UPDATE_DEBOUNCE_MS);
+
+    pendingBadgeUpdateTimers.set(tabId, timer);
+  }
+
+  // タブ切り替え時にバッジを更新
+  chrome.tabs.onActivated.addListener(({ tabId }) => {
+    requestTabBadgeUpdate(tabId);
+  });
+
+  // ページ遷移完了時にバッジを更新（アクティブタブのみ）
+  chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (changeInfo.status === "complete" && tab.active) {
+      requestTabBadgeUpdate(tabId);
+    }
+  });
+
+  // タブ削除時にデバウンスタイマーをクリーンアップ
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    const timer = pendingBadgeUpdateTimers.get(tabId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      pendingBadgeUpdateTimers.delete(tabId);
+    }
+  });
+
+  // NOTE: インストール直後の更新は Content Script の注入を待つ必要があるため、
+  // onInstalled を分けずに呼び出し側から順序を保って呼ぶ
+  return { requestTabBadgeUpdate };
+}

--- a/packages/extension-common/src/tab-badge/background.ts
+++ b/packages/extension-common/src/tab-badge/background.ts
@@ -6,7 +6,6 @@ const BADGE_UPDATE_DEBOUNCE_MS = 300;
 /**
  * タブのバッジ更新の Service Worker 側イベント配線を登録する
  * @param countCredentials タブのバッジに表示するクレデンシャルの件数を数える
- * @returns バッジ更新をデバウンス付きで要求する関数
  */
 export function setupTabBadge(
   countCredentials: (tabId: number) => Promise<number>,


### PR DESCRIPTION
## 変更内容

> ベースは #521 です。先にそちらをご覧ください。

#521 で広告リンク検証の Service Worker 配線を `link-verification` へ移したのと同じことを `tab-badge` にもおこないます。`tab-badge/background.ts` に `setupTabBadge(countCredentials)` として切り出しました。

`setupBackground` は 186 行になり、残るのはサイドパネル / サイドバー、インストール時の初期化、フレーム CAS、Basic Auth の 4 話題です。

**`onInstalled` は分けていません。** インストール直後のバッジ更新は `countCredentials` がタブへメッセージを送るため Content Script の注入完了に依存しており、リスナーを 2 本に割ると両者の順序が保証されなくなります。`setupTabBadge` が `requestTabBadgeUpdate` を返し、呼び出し側が注入の後に呼ぶ形にしました。

#521 で `onRemoved` を分けたのと判断が分かれますが、あちらは互いに素な状態を破棄するだけで依存がなく、こちらには実際の依存があります。

参照: #515

## 確認手順

- `pnpm --filter=@originator-profile/extension-common run test` — 48 件通過
- `pnpm --filter=@originator-profile/inspector run e2e` — 38 件中 37 passed / 1 skipped (`tab-badge.test.ts` 2 件を含む)
- `tsc --noEmit` / `oxlint` / `prettier --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7EwFqHUwePrS9xmeFMFMo
