### PR TITLE
feat: VisibleTextTargetIntegrity を非推奨化

### DIFF
--- a/packages/model/src/target/basic-target.ts
+++ b/packages/model/src/target/basic-target.ts
@@ -4,6 +4,11 @@ import { SubresourceIntegrity } from "../sri";
 export const BasicTarget = z.looseObject({
   type: z.enum([
     "TextTargetIntegrity",
+    /**
+     * @deprecated innerText によるレンダリング結果はブラウザ実装に依存し、ブラウザ間で一致しない。
+     * 完全性検証の根拠にはできないため、2027-10-01 以降に廃止する。
+     * @see https://docs.originator-profile.org/opb/content-integrity-descriptor/visible-text/
+     */
     "VisibleTextTargetIntegrity",
     "HtmlTargetIntegrity",
   ]),

--- a/packages/verify/src/content-attestation/verify-content-attestation.ts
+++ b/packages/verify/src/content-attestation/verify-content-attestation.ts
@@ -46,6 +46,42 @@ function warnAllowedOriginDeprecated(
   });
 }
 
+/** VisibleTextTargetIntegrity の非推奨を通知する */
+function warnVisibleTextTargetIntegrityDeprecated(
+  logger: Logger,
+  subject: string,
+  at?: string,
+): void {
+  const message = `\
+[OP Warning] VisibleTextTargetIntegrity is deprecated in Content Attestation and will be removed after October 2027. \
+innerText-based rendering is platform-dependent and incompatible across browser implementations and cannot serve as a basis for integrity verification. \
+See: https://docs.originator-profile.org/opb/content-integrity-descriptor/visible-text/`;
+  logger.warn(message, {
+    type: ProblemType.VisibleTextTargetIntegrityDeprecated,
+    title: message,
+    detail: subject,
+    ...(at && { pointer: at }),
+  });
+}
+
+/** target 内の非推奨な Target Integrity を通知する */
+function warnDeprecatedTargets<T extends ContentAttestation>(
+  result: VerifiedCa<T>,
+  logger: Logger,
+  at?: string,
+): void {
+  const hasVisibleTextTarget = result.doc.target?.some(
+    (t) => t.type === "VisibleTextTargetIntegrity",
+  );
+  if (hasVisibleTextTarget) {
+    warnVisibleTextTargetIntegrityDeprecated(
+      logger,
+      result.doc.credentialSubject.id,
+      at,
+    );
+  }
+}
+
 async function checkUrlAndOrigin<T extends ContentAttestation>(
   result: VerifiedCa<T>,
   url: URL,
@@ -168,6 +204,8 @@ export function CaVerifier<T extends ContentAttestation>(
       if (urlResult.doc.target.length === 0) {
         return new CaInvalid("Target is empty", urlResult);
       }
+
+      warnDeprecatedTargets(urlResult, logger, at);
 
       const integrityResults: IntegrityResult[] = await Promise.all(
         urlResult.doc.target.map(async (t, index) => ({

--- a/packages/verify/src/result/problem-types.ts
+++ b/packages/verify/src/result/problem-types.ts
@@ -21,6 +21,10 @@ export const ProblemType = {
   CertificateDeprecated: problemType("WARN_CERTIFICATE_DEPRECATED"),
   /** Content Attestation の allowedOrigin は非推奨 */
   AllowedOriginDeprecated: problemType("WARN_ALLOWED_ORIGIN_DEPRECATED"),
+  /** Content Attestation の VisibleTextTargetIntegrity は非推奨 */
+  VisibleTextTargetIntegrityDeprecated: problemType(
+    "WARN_VISIBLE_TEXT_TARGET_INTEGRITY_DEPRECATED",
+  ),
   /** digestSRI が設定されていない */
   DigestSriMissing: problemType("WARN_DIGEST_SRI_MISSING"),
   /** digestSRI の検証に失敗した */

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -189,9 +189,9 @@ Without `cssSelector`, you must manually set the `integrity` attribute on each `
 <img src="https://example.com/image.png" integrity="sha256-..." />
 ```
 
-### `VisibleTextTargetIntegrity` may not match browser verification
+### `VisibleTextTargetIntegrity` may not match browser verification (deprecated)
 
-[`VisibleTextTargetIntegrity`](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/visible-text/) computes integrity from the "as rendered" visible text (`element.innerText`), which depends on browser layout and CSS. This plugin computes integrity at build time using a DOM parser without rendering, so the result may differ from what the browser extension calculates. Use `TextTargetIntegrity` or `HtmlTargetIntegrity` for reliable build-time integrity computation.
+[`VisibleTextTargetIntegrity` ⚠](https://docs.originator-profile.org/en/opb/content-integrity-descriptor/visible-text/) computes integrity from the "as rendered" visible text (`element.innerText`), which depends on browser layout and CSS. This plugin computes integrity at build time using a DOM parser without rendering, so the result may differ from what the browser extension calculates. Use `TextTargetIntegrity` or `HtmlTargetIntegrity` for reliable build-time integrity computation.
 
 ### DOM target integrity is computed against the pre-transform HTML
 

--- a/packages/wordpress/includes/admin.php
+++ b/packages/wordpress/includes/admin.php
@@ -186,7 +186,7 @@ function profile_ca_target_type_field() {
 		<datalist id="target_integrity_type">
 			<option>HtmlTargetIntegrity</option>
 			<option>TextTargetIntegrity</option>
-			<option>VisibleTextTargetIntegrity</option>
+			<option value="VisibleTextTargetIntegrity">VisibleTextTargetIntegrity (deprecated)</option>
 		</datalist>
 	<?php
 }


### PR DESCRIPTION
## Summary

- `innerText` によるレンダリング結果はブラウザ実装に依存し、ブラウザ間で一致しない（[originator-profile/originator-profile#64](https://github.com/originator-profile/originator-profile/issues/64)、WebKit で追加の改行が入る等）ため、完全性検証の根拠として使用できないことから `VisibleTextTargetIntegrity` を非推奨化
- Certificate 非推奨化（`WARN_CERTIFICATE_DEPRECATED`）の実装パターンに倣い、`allowedOrigin` 非推奨警告と同様の deprecation 警告を追加
  - `packages/verify/src/result/problem-types.ts`: `ProblemType.VisibleTextTargetIntegrityDeprecated` を追加
  - `packages/verify/src/content-attestation/verify-content-attestation.ts`: CA の `target` に `VisibleTextTargetIntegrity` が含まれる場合、検証時に `console.warn` で通知（検証処理自体は継続）
  - `packages/model/src/target/basic-target.ts`: スキーマの型定義に `@deprecated` JSDoc を追加
- ドキュメント・管理画面にも非推奨であることを表示
  - `packages/vite-plugin/README.md`
  - `packages/wordpress/includes/admin.php`

対応する docs 側の非推奨マーク: https://github.com/originator-profile/docs.originator-profile.org/pull/562

Ref: https://github.com/originator-profile/docs.originator-profile.org/issues/561

## Test plan

- [x] `packages/verify` の関連テスト（`verify-allowed-origin-deprecation.test.ts`, `verify-content-attestation.test.ts`）が通ることを確認
- [x] 変更ファイルの `prettier --check` / `oxlint` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)