### PR TITLE
fix(ci): lerna.json に npmClient と syncWorkspaceLock を明示する

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/lerna-lite/lerna-lite/main/packages/cli/schemas/lerna-schema.json",
   "version": "0.7.0-beta.4",
+  "npmClient": "pnpm",
   "packages": [
     ".",
     "apps/*",
@@ -8,7 +9,8 @@
   ],
   "command": {
     "version": {
-      "forcePublish": true
+      "forcePublish": true,
+      "syncWorkspaceLock": true
     }
   }
 }


### PR DESCRIPTION
## 事象

[canary ワークフローの実行](https://github.com/originator-profile/originator-profile/actions/runs/34448395916) が失敗していた。
"Bump canary version" ステップの中で `lerna version` の version ライフサイクルスクリプトが turborepo 経由の全パッケージビルドを起動する。
そのビルドのうち `cas-generator` パッケージで `pnpm run build` が失敗し、ジョブ全体が異常終了していた。
失敗の直接のログは次のとおりで、`postinstall` が呼ぶ `nuxt prepare` が `nuxt` コマンドを見つけられていない。

```
../cas-generator postinstall$ nuxt prepare
. postinstall: sh: 1: nuxt: not found
```

## 原因

`lerna version` 実行直後のログに、次の警告が出ていた。

```
lerna-lite WARN npm we recommend using --sync-workspace-lock which will sync your lock file via your favorite npm client instead of relying on Lerna-Lite itself to update it.
```

この警告が示すとおり、`lerna version` は各パッケージの `package.json` のバージョンを書き換える一方、ルートの `pnpm-lock.yaml` はそのままだった。
[`@lerna-lite/version` のドキュメント](https://www.npmjs.com/package/@lerna-lite/version#--sync-workspace-lock) によれば、この不整合を lock ファイル側に反映する処理はオプトインで、`npmClient` に応じたコマンド（pnpm なら `pnpm install --lockfile-only`）を実行する。
このリポジトリの `lerna.json` には `npmClient` の指定がなく、同ドキュメントにあるとおり `npmClient` は未指定時 `npm` がデフォルトになる。
実態は pnpm（`pnpm-lock.yaml` と `packageManager: pnpm@11.0.9`）であり、ここで認識が食い違っていた。

pnpm には、`package.json` と `pnpm-lock.yaml` の不整合を検知すると `pnpm run` 実行時に依存関係を自動で再解決する仕組みがある。
バージョン書き換え直後、turborepo が複数パッケージのビルドを並行実行するタイミングでこの自動再解決が複数タスクから同時に走り、互いを `SIGINT` で中断させ合っていた。
その影響で `cas-generator` の `postinstall` が呼ぶ `nuxt` のインストールが完了しないまま `nuxt prepare` が実行され、失敗に至ったと見られる。

## 対応

`lerna.json` に `npmClient: "pnpm"` を明示し、実態に合わせた。
あわせて `command.version.syncWorkspaceLock` を有効にし、`lerna version` 実行時に lock ファイルの同期処理を必ず走らせるようにした。
これにより、バージョン書き換えと `pnpm-lock.yaml` の同期が同じタイミングで完了し、後続のビルドで不整合を検知した自動再解決が発生しなくなる見込み。

いずれも `command`/`lerna.json` の設定のみの変更で、ワークフロー側の変更は不要だった。

## Test plan

- [ ] canary ワークフローが正常に完了することを確認する