### PR TITLE
fix(inspector): Fix typo in overlay CSS: outilne → outline

### DIFF
--- a/apps/inspector/src/components/overlay/overlay.ts
+++ b/apps/inspector/src/components/overlay/overlay.ts
@@ -34,7 +34,7 @@ export class Overlay {
       padding: 0;
       opacity: 1;
       visibility: visible;
-      outilne: 0;
+      outline: 0;
       z-index: calc(infinity);
   `;
   }


### PR DESCRIPTION
## 変更内容

overlay.ts の CSS スタイル定義内のタイポを修正しました。
`outilne: 0;` を正しい `outline: 0;` に修正しています。

このタイポにより、CSS プロパティが正しく適用されていませんでした。

## 確認手順

- CSS の outline プロパティが正しく適用されることを確認
- inspector のオーバーレイ表示に問題がないことを確認

https://claude.ai/code/session_01LYynssutdoeDp2E87iBSqz