### PR TITLE
fix(op-lens): 複製後に inspector 側だけ直った不具合を取り込む

### DIFF
--- a/apps/lens/src/components/CheckList.tsx
+++ b/apps/lens/src/components/CheckList.tsx
@@ -645,12 +645,18 @@ function ContentAttestationSetCheck({
 
 function DisplayOtherErrors({ errors }: { errors: Error[] }) {
   return (
-    <div className="pl-4">
+    <div className="pl-4" data-testid="other-errors">
       <h2 className="mt-4 mb-4 text-sm font-bold text-gray-700">
         {_("OtherErrors")}
       </h2>
       {errors.map((error, index) => (
-        <DisplayResults key={index} payload={error} className="pl-2 mb-2" />
+        <DisplayResults
+          key={index}
+          code={isCodedError(error) ? error.code : undefined}
+          message={error.message}
+          payload={error}
+          className="pl-2 mb-2"
+        />
       ))}
     </div>
   );
@@ -669,7 +675,6 @@ function CheckList({
   errors: Error[];
 }) {
   const codedErrors = errors.filter(isCodedError);
-  const nonCodedErrors = errors.filter((e) => !isCodedError(e));
 
   const spError = findError(codedErrors, [
     "ERR_SITE_PROFILE_FETCH_INVALID",
@@ -693,6 +698,12 @@ function CheckList({
   ]);
 
   const contentAttestationSet = casError ?? cas;
+
+  // NOTE: 振り分けは code の有無ではなく「行に割り当てられたか」で決める。code を
+  // 持つかで分けると、どの行にも対応しないコードのエラーが表示から消える。
+  const assigned: (Error | undefined)[] = [spError, opsError, casError];
+  const otherErrors = errors.filter((error) => !assigned.includes(error));
+
   // 検証済みの CAS は配列として渡されますが、空配列はエラー扱いされない仕様です。
   // そのため、空配列であることを明示的に判定して扱いを分岐します。
   const isEmptyVerifiedCas =
@@ -739,9 +750,7 @@ function CheckList({
           <DisplayResults payload={cas} className="ml-7" />
         </DetailItem>
       )}
-      {nonCodedErrors.length !== 0 && (
-        <DisplayOtherErrors errors={nonCodedErrors} />
-      )}
+      {otherErrors.length !== 0 && <DisplayOtherErrors errors={otherErrors} />}
     </>
   );
 }

--- a/apps/lens/src/components/Unsupported.tsx
+++ b/apps/lens/src/components/Unsupported.tsx
@@ -3,17 +3,22 @@ import GlobalHeader from "./GlobalHeader";
 import { linkVerificationTitle } from "./credentials/link-verification-title";
 import { useLinkVerification } from "./credentials/use-link-verification";
 
+// NOTE: getMessage は未定義のキーに空文字を返す。訳はエラーコードとは別々に
+// 増えるため、訳の引けないコードとコードのないエラーは区別せず同じ文言にする。
+function messageOf(error: Error): string {
+  const code = "code" in error ? (error.code as string) : undefined;
+  return (code && _(`Unsupported_${code}`)) || _("Unsupported_UnknownError");
+}
+
 function Messages({ errors }: { errors: Error[] }) {
-  const errorWithCode = errors.filter((error) => "code" in error);
-  const hasOtherErrors = errors.length !== errorWithCode.length;
+  // 別のコードでも同じ文言になることがあるため、重複を落とす
+  const messages = [...new Set(errors.map(messageOf))];
 
   return (
     <ul className="list-disc list-inside text-sm max-w-xs mx-auto">
-      {errorWithCode.length > 0 &&
-        errorWithCode.map((error, index) => (
-          <li key={index}>{_(`Unsupported_${error.code as string}`)}</li>
-        ))}
-      {hasOtherErrors && <li>{_("Unsupported_UnknownError")}</li>}
+      {messages.map((message, index) => (
+        <li key={index}>{message}</li>
+      ))}
     </ul>
   );
 }

--- a/apps/lens/src/components/overlay/overlay.ts
+++ b/apps/lens/src/components/overlay/overlay.ts
@@ -34,7 +34,7 @@ export class Overlay {
       padding: 0;
       opacity: 1;
       visibility: visible;
-      outilne: 0;
+      outline: 0;
       z-index: calc(infinity);
   `;
   }


### PR DESCRIPTION
## 変更内容

`apps/lens` は #531 で `apps/inspector` を複製して作りましたが、複製の分岐点より後に inspector 側だけへ入った修正が 2 件あり、lens に古いコードが残っていました。これを同期します。

| コミット | 内容 | 出所 |
| --- | --- | --- |
| `9cafd7cd` | オーバーレイ CSS の `outilne` → `outline` | #532 (issue: #537) |
| `de6caae9` | 非サポート画面と詳細情報でエラーの理由が消えるのを直す | #528 |

同期後、`apps/inspector/src` と `apps/lens/src` は**全ファイル一致**します（`diff -rq` で確認）。

close #537
ref #528

### e2e は追加していません

#528 が足した `e2e/content-script-unreachable.test.ts` は非サポート画面の DOM (`p-elm-unsupported-message` / `other-errors`) と日本語文言を参照します。#531 が「OP Lens 自身の配線を見るものだけ残す」として外した 17 ファイルとまったく同じ性質なので、同じ方針で追加していません。#487 / #502 / #503 / #505 でサイドパネルの画面ができた段に、`apps/inspector/e2e` から起こすのが筋だと考えています。

同じ理由で `e2e/fixtures.ts` の `sidepanel(ctx, forTabId?)` も同期していません。この引数は上記テストのためだけに増えたもので、lens 側では使い道がないためです。

### 共有コードは既に効いています

#528 が触った `packages/extension-common/src/credentials/messaging.ts`（フレーム取得失敗時の `Object.assign` 正規化をやめる変更）は両拡張機能が共有しているため、lens にも既に反映されています。

## 確認手順

```bash
pnpm exec prettier --check apps/lens
pnpm exec turbo run lint test --filter=@originator-profile/lens

# 複製元との差がないこと
diff -rq apps/inspector/src apps/lens/src
```

### 手元で確認した結果

- `prettier --check apps/lens`: 通過
- `turbo run lint test --filter=@originator-profile/lens`: lint 0 warnings / 0 errors、test 19 passed (3 files)
- `diff -rq apps/inspector/src apps/lens/src`: 差分なし

e2e は未実行です（ブラウザーを起動するためコンテナが必要）。lens に残っている 2 ファイル (`tab-badge.test.ts` / `en/ui-language.test.ts`) は今回触った 3 ファイルの DOM を参照しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7hYRD8wNVdQYG9oe2b78w