### PR TITLE
fix(inspector): リンク先確認 e2e の遷移先判定をホスト名の完全一致にする

### DIFF
--- a/apps/inspector/e2e/link-verification.test.ts
+++ b/apps/inspector/e2e/link-verification.test.ts
@@ -143,7 +143,7 @@ test.describe("リンク検証", () => {
 
     // Proceed をクリック → 遷移先（example.com）へ進む
     await proceedButton.click();
-    await page.waitForURL((url) => url.href.includes("example.com"), {
+    await page.waitForURL((url) => url.hostname === "example.com", {
       timeout: 10_000,
     });
   });


### PR DESCRIPTION
## 変更内容

CodeQL の `js/incomplete-url-substring-sanitization` ([alert #8](https://github.com/originator-profile/originator-profile/security/code-scanning/8)) を解消します。#531 のレビューで指摘されたものと同じコードです（指摘は `apps/op-lens/e2e/link-verification.test.ts` を指していますが、#531 の最終形で lens の e2e は削除済みのため、残っているのは inspector 側だけでした）。

```diff
-await page.waitForURL((url) => url.href.includes("example.com"), {
+await page.waitForURL((url) => url.hostname === "example.com", {
   timeout: 10_000,
 });
```

`href.includes("example.com")` は URL のどこに現れても真になるため、`https://evil.test/?next=example.com` のような別ホストへ遷移しても通ってしまいます。遷移先は `dev/public/examples/verify-link.html:160` が固定で持つ `https://example.com` なので、`hostname` の完全一致で判定できます。

同ファイルの残り 2 箇所（`/examples/verify-link.html` と `/examples/valid-dest.html`）はホストではなくパスの判定なので、そのままにしています。

## 確認手順

```bash
pnpm exec turbo run lint --filter=@originator-profile/inspector
cd apps/inspector && NODE_ENV=testing pnpm e2e -g "Proceed anyway"
```

### 手元で確認した結果

- `lint`: 0 warnings / 0 errors
- `prettier --check apps/inspector/e2e`: 通過

e2e は未実行です（ブラウザーを起動するためコンテナが必要）。CI の End-to-End Test で通ることを見てください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7hYRD8wNVdQYG9oe2b78w