### PR TITLE
skill: clsx から twMerge に移行済みなので注釈を外す

### DIFF
--- a/.github/skills/originator-profile-frontend/references/styling-guide.md
+++ b/.github/skills/originator-profile-frontend/references/styling-guide.md
@@ -26,10 +26,6 @@ function Button({ className, children }: Props) {
 <Button className="bg-danger">削除</Button>;
 ```
 
-> [!NOTE]
-> clsx を使用している箇所は tailwind-merge へ移行予定です。新規コードでは `twMerge` を使用してください。
-> Issue: [clsx の代わりに tailwind-merge を導入する提案 · Issue #45 · originator-profile/originator-profile](https://github.com/originator-profile/originator-profile/issues/45)
-
 ## コンポーネントは自身より外側に影響を与えるスタイルをデフォルトで持たない
 
 コンポーネントの outer element に `margin` などの外部に影響を与えるプロパティをデフォルトで設定しない。余白の制御は親要素が行う。


### PR DESCRIPTION

## 変更内容

(何を・なぜ変更したか)
https://github.com/originator-profile/originator-profile/pull/336 にて clsx から twMerge に前面移行したが、フロントエンド実装用スキルに移行前の注釈が残っていた。実態にあわせてそれを削除します。

<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

## 確認手順

(どうやって変更内容を確認した・してほしいか)
スタイルガイドが実態に沿っているかどうか読む